### PR TITLE
Add configuration option to expand refresh token ttl

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -32,6 +32,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->integerNode('ttl')->defaultValue('2592000')->end()
+                ->booleanNode('ttl_update')->defaultFalse()->end()
                 ->scalarNode('firewall')->defaultValue('api')->end()
             ->end();
 

--- a/DependencyInjection/GesdinetJWTRefreshTokenExtension.php
+++ b/DependencyInjection/GesdinetJWTRefreshTokenExtension.php
@@ -35,6 +35,7 @@ class GesdinetJWTRefreshTokenExtension extends Extension
         $loader->load('services.yml');
 
         $container->setParameter('gesdinet_jwt_refresh_token.ttl', $config['ttl']);
+        $container->setParameter('gesdinet_jwt_refresh_token.ttl_update', $config['ttl_update']);
         $container->setParameter('gesdinet_jwt_refresh_token.security.firewall', $config['firewall']);
 //        $container->setParameter('gesdinet_jwt_refresh_token.model_manager_name', $config['model_manager_name']);
     }

--- a/README.md
+++ b/README.md
@@ -110,6 +110,17 @@ gesdinet_jwt_refresh_token:
     ttl: 2592000
 ```
 
+### Config TTL update
+
+You can expand Refresh Token TTL on refresh. Default value is false. You can change this value adding this line to your config.yml file:
+
+```yaml
+gesdinet_jwt_refresh_token:
+    ttl_update: true
+```
+
+This will reset the token TTL each time you ask a refresh.
+
 ### Config Firewall Name
 
 You can define Firewall name. Default value is api. You can change this value adding this line to your config.yml file:

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -14,7 +14,7 @@ services:
 
     gesdinet.jwtrefreshtoken:
         class: Gesdinet\JWTRefreshTokenBundle\Service\RefreshToken
-        arguments: [@gesdinet.jwtrefreshtoken.authenticator, @gesdinet.jwtrefreshtoken.user_provider, @lexik_jwt_authentication.handler.authentication_success, @lexik_jwt_authentication.handler.authentication_failure, @gesdinet.jwtrefreshtoken.refresh_token_manager, %gesdinet_jwt_refresh_token.ttl%, %gesdinet_jwt_refresh_token.security.firewall%]
+        arguments: [@gesdinet.jwtrefreshtoken.authenticator, @gesdinet.jwtrefreshtoken.user_provider, @lexik_jwt_authentication.handler.authentication_success, @lexik_jwt_authentication.handler.authentication_failure, @gesdinet.jwtrefreshtoken.refresh_token_manager, %gesdinet_jwt_refresh_token.ttl%, %gesdinet_jwt_refresh_token.security.firewall%, %gesdinet_jwt_refresh_token.ttl_update%]
 
     gesdinet.jwtrefreshtoken.user_provider:
         class: Gesdinet\JWTRefreshTokenBundle\Security\Provider\RefreshTokenProvider

--- a/Service/RefreshToken.php
+++ b/Service/RefreshToken.php
@@ -29,8 +29,10 @@ class RefreshToken
     private $successHandler;
     private $failureHandler;
     private $refreshTokenManager;
+    private $ttl;
+    private $ttlUpdate;
 
-    public function __construct(RefreshTokenAuthenticator $authenticator, RefreshTokenProvider $provider, AuthenticationSuccessHandler $successHandler, AuthenticationFailureHandler $failureHandler, RefreshTokenManagerInterface $refreshTokenManager, $ttl, $providerKey)
+    public function __construct(RefreshTokenAuthenticator $authenticator, RefreshTokenProvider $provider, AuthenticationSuccessHandler $successHandler, AuthenticationFailureHandler $failureHandler, RefreshTokenManagerInterface $refreshTokenManager, $ttl, $providerKey, $ttlUpdate)
     {
         $this->authenticator = $authenticator;
         $this->provider = $provider;
@@ -39,6 +41,7 @@ class RefreshToken
         $this->refreshTokenManager = $refreshTokenManager;
         $this->ttl = $ttl;
         $this->providerKey = $providerKey;
+        $this->ttlUpdate = $ttlUpdate;
     }
 
     /**
@@ -67,6 +70,13 @@ class RefreshToken
                             sprintf('Refresh token "%s" is invalid.', $refreshToken)
                             )
             );
+        }
+
+        if ($this->ttlUpdate) {
+            $modifier = sprintf('+%d seconds', $this->ttl);
+            $refreshToken->getValid()->modify($modifier);
+
+            $this->refreshTokenManager->save($refreshToken);
         }
 
         return $this->successHandler->onAuthenticationSuccess($request, $preAuthenticatedToken);


### PR DESCRIPTION
To improve application security, I want to set a small refresh token TTL.

This PR allow to update the refresh token TTL after each refresh request. This that option, we can define a smaller TTL which allow user to renew his JWT token as long his session is valid.