### PR TITLE
Force new object to set expiration date to avoid fix error on some Doctrine version

### DIFF
--- a/Service/RefreshToken.php
+++ b/Service/RefreshToken.php
@@ -73,8 +73,9 @@ class RefreshToken
         }
 
         if ($this->ttlUpdate) {
-            $modifier = sprintf('+%d seconds', $this->ttl);
-            $refreshToken->getValid()->modify($modifier);
+            $expirationDate = new \DateTime();
+            $expirationDate->modify(sprintf('+%d seconds', $this->ttl));
+            $refreshToken->setValid($expirationDate);
 
             $this->refreshTokenManager->save($refreshToken);
         }

--- a/spec/Service/RefreshTokenSpec.php
+++ b/spec/Service/RefreshTokenSpec.php
@@ -52,7 +52,7 @@ class RefreshTokenSpec extends ObjectBehavior
         $refreshTokenManager->get(Argument::any())->willReturn($refreshToken);
         $refreshToken->isValid()->willReturn(true);
 
-        $refreshToken->getValid()->willReturn(new \DateTime());
+        $refreshToken->setValid(Argument::any())->shouldBeCalled();
         $refreshTokenManager->save($refreshToken)->shouldBeCalled();
 
         $this->refresh($request);


### PR DESCRIPTION
We notice that on some Doctrine version, the expiration date is not modify in database.

This is the fix, to force a new DateTime object that will be considered by Doctrine for the update.

This is related to previous PR #25 .
Really sorry for the inconvenience.