### PR TITLE
service parameters are now quoted according to YAML specifications

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,21 +4,21 @@ parameters:
 services:
     gesdinet.jwtrefreshtoken.send_token:
         class: Gesdinet\JWTRefreshTokenBundle\EventListener\AttachRefreshTokenOnSuccessListener
-        arguments: [ @gesdinet.jwtrefreshtoken.refresh_token_manager, %gesdinet_jwt_refresh_token.ttl%, @validator]
+        arguments: [ "@gesdinet.jwtrefreshtoken.refresh_token_manager", "%gesdinet_jwt_refresh_token.ttl%", "@validator" ]
         tags:
             - { name: kernel.event_listener, event: lexik_jwt_authentication.on_authentication_success, method: attachRefreshToken }
 
     gesdinet.jwtrefreshtoken.refresh_token_manager:
         class: Gesdinet\JWTRefreshTokenBundle\Doctrine\RefreshTokenManager
-        arguments: [@doctrine.orm.entity_manager, %gesdinet.jwtrefreshtoken.refresh_token.class%]
+        arguments: [ "@doctrine.orm.entity_manager", "%gesdinet.jwtrefreshtoken.refresh_token.class%" ]
 
     gesdinet.jwtrefreshtoken:
         class: Gesdinet\JWTRefreshTokenBundle\Service\RefreshToken
-        arguments: [@gesdinet.jwtrefreshtoken.authenticator, @gesdinet.jwtrefreshtoken.user_provider, @lexik_jwt_authentication.handler.authentication_success, @lexik_jwt_authentication.handler.authentication_failure, @gesdinet.jwtrefreshtoken.refresh_token_manager, %gesdinet_jwt_refresh_token.ttl%, %gesdinet_jwt_refresh_token.security.firewall%, %gesdinet_jwt_refresh_token.ttl_update%]
+        arguments: [ "@gesdinet.jwtrefreshtoken.authenticator", "@gesdinet.jwtrefreshtoken.user_provider", "@lexik_jwt_authentication.handler.authentication_success", "@lexik_jwt_authentication.handler.authentication_failure", "@gesdinet.jwtrefreshtoken.refresh_token_manager", "%gesdinet_jwt_refresh_token.ttl%", "%gesdinet_jwt_refresh_token.security.firewall%", "%gesdinet_jwt_refresh_token.ttl_update%" ]
 
     gesdinet.jwtrefreshtoken.user_provider:
         class: Gesdinet\JWTRefreshTokenBundle\Security\Provider\RefreshTokenProvider
-        arguments: [@gesdinet.jwtrefreshtoken.refresh_token_manager]
+        arguments: [ "@gesdinet.jwtrefreshtoken.refresh_token_manager" ]
 
     gesdinet.jwtrefreshtoken.authenticator:
         class: Gesdinet\JWTRefreshTokenBundle\Security\Authenticator\RefreshTokenAuthenticator


### PR DESCRIPTION
More recent versions of PHPUnit trip up over un-quoted '@' characters in YAML files - simply quoting service arguments fixes this and doesn't appear to cause any untoward behaviour as a result.