### PR TITLE
Raise minimum Symfony version to 2.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   ],
   "require" : {
     "php": ">=5.3.3",
-    "symfony/symfony": ">=2.5",
+    "symfony/symfony": ">=2.5,<2.8",
     "doctrine/orm": "^2.4.8",
     "doctrine/doctrine-bundle": "~1.4",
     "lexik/jwt-authentication-bundle": "^1.1"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   ],
   "require" : {
     "php": ">=5.3.3",
-    "symfony/symfony": "~2.3",
+    "symfony/symfony": ">=2.5",
     "doctrine/orm": "^2.4.8",
     "doctrine/doctrine-bundle": "~1.4",
     "lexik/jwt-authentication-bundle": "^1.1"


### PR DESCRIPTION
ValidatorInterface used in AttachRefreshTokenOnSuccessListener was moved and deprecated in 2.5: https://github.com/symfony/validator/blob/master/CHANGELOG.md