### PR TITLE
Using a custom UserProvider (issue #36)

### DIFF
--- a/DependencyInjection/Compiler/CustomUserProviderCompilerPass.php
+++ b/DependencyInjection/Compiler/CustomUserProviderCompilerPass.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Gesdinet\JWTRefreshTokenBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * CustomUserProviderCompilerPass.
+ */
+final class CustomUserProviderCompilerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $customUserProvider = $container->getParameter('gesdinet_jwt_refresh_token.user_provider');
+        if (!$customUserProvider) {
+            return;
+        }
+        if (!$container->hasDefinition('gesdinet.jwtrefreshtoken.user_provider')) {
+            return;
+        }
+
+        $definition = $container->getDefinition('gesdinet.jwtrefreshtoken.user_provider');
+
+        $definition->addMethodCall(
+            'setCustomUserProvider',
+            [new Reference($customUserProvider, ContainerInterface::NULL_ON_INVALID_REFERENCE, false)]
+        );
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -34,6 +34,7 @@ class Configuration implements ConfigurationInterface
                 ->integerNode('ttl')->defaultValue('2592000')->end()
                 ->booleanNode('ttl_update')->defaultFalse()->end()
                 ->scalarNode('firewall')->defaultValue('api')->end()
+                ->scalarNode('user_provider')->defaultNull()->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/GesdinetJWTRefreshTokenExtension.php
+++ b/DependencyInjection/GesdinetJWTRefreshTokenExtension.php
@@ -37,6 +37,7 @@ class GesdinetJWTRefreshTokenExtension extends Extension
         $container->setParameter('gesdinet_jwt_refresh_token.ttl', $config['ttl']);
         $container->setParameter('gesdinet_jwt_refresh_token.ttl_update', $config['ttl_update']);
         $container->setParameter('gesdinet_jwt_refresh_token.security.firewall', $config['firewall']);
+        $container->setParameter('gesdinet_jwt_refresh_token.user_provider', $config['user_provider']);
 //        $container->setParameter('gesdinet_jwt_refresh_token.model_manager_name', $config['model_manager_name']);
     }
 }

--- a/GesdinetJWTRefreshTokenBundle.php
+++ b/GesdinetJWTRefreshTokenBundle.php
@@ -2,8 +2,16 @@
 
 namespace Gesdinet\JWTRefreshTokenBundle;
 
+use Gesdinet\JWTRefreshTokenBundle\DependencyInjection\Compiler\CustomUserProviderCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class GesdinetJWTRefreshTokenBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new CustomUserProviderCompilerPass());
+    }
 }

--- a/README.md
+++ b/README.md
@@ -130,6 +130,17 @@ gesdinet_jwt_refresh_token:
     firewall: api
 ```
 
+### Config UserProvider
+
+You can define your own UserProvider. By default we use our custom UserProvider. You can change this value by adding this line to your config.yml file:
+
+```yaml
+gesdinet_jwt_refresh_token:
+    user_provider: user_provider_service_id
+```
+
+For example, if you are using FOSUserBundle, user_provider_service_id must be set to `fos_user.user_provider.username_email`.
+
 ### Generating Tokens
 
 When you authenticate through /api/login_check with user/password credentials, LexikJWTAuthenticationBundle now returns a JWT Token and a Refresh Token data.

--- a/Security/Provider/RefreshTokenProvider.php
+++ b/Security/Provider/RefreshTokenProvider.php
@@ -24,10 +24,16 @@ use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
 class RefreshTokenProvider implements UserProviderInterface
 {
     protected $refreshTokenManager;
+    protected $customUserProvider;
 
     public function __construct(RefreshTokenManagerInterface $refreshTokenManager)
     {
         $this->refreshTokenManager = $refreshTokenManager;
+    }
+
+    public function setCustomUserProvider(UserProviderInterface $customUserProvider)
+    {
+        $this->customUserProvider = $customUserProvider;
     }
 
     public function getUsernameForRefreshToken($token)
@@ -43,20 +49,32 @@ class RefreshTokenProvider implements UserProviderInterface
 
     public function loadUserByUsername($username)
     {
-        return new User(
-            $username,
-            null,
-            array('ROLE_USER')
-        );
+        if ($this->customUserProvider != null) {
+            return $this->customUserProvider->loadUserByUsername($username);
+        } else {
+            return new User(
+                $username,
+                null,
+                array('ROLE_USER')
+            );
+        }
     }
 
     public function refreshUser(UserInterface $user)
     {
-        throw new UnsupportedUserException();
+        if ($this->customUserProvider != null) {
+            return $this->customUserProvider->refreshUser($user);
+        } else {
+            throw new UnsupportedUserException();
+        }
     }
 
     public function supportsClass($class)
     {
-        return 'Symfony\Component\Security\Core\User\User' === $class;
+        if ($this->customUserProvider != null) {
+            return $this->customUserProvider->supportsClass($class);
+        } else {
+            return 'Symfony\Component\Security\Core\User\User' === $class;
+        }
     }
 }


### PR DESCRIPTION
This PullRequest answer to issue #36 .

I added a new configuration parameter 'user_provider', where we can provide the id of UserProvider we are using.

For example, if using FOSUserBundle's userProvider, we'll add those lines to the config.yml of our app:

    gesdinet_jwt_refresh_token:
        user_provider: fos_user.user_provider.username_email

If user_provider is not set, the default behaviour is used.
