### PR TITLE
fixed bug when running `app/console clear:cache`

### DIFF
--- a/DependencyInjection/Compiler/EntityManagerCompilerPass.php
+++ b/DependencyInjection/Compiler/EntityManagerCompilerPass.php
@@ -8,19 +8,18 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 /**
  * CustomUserProviderCompilerPass.
  */
-final class CustomEntityManagerCompilerPass implements CompilerPassInterface
+final class EntityManagerCompilerPass implements CompilerPassInterface
 {
     /**
      * {@inheritdoc}
      */
     public function process(ContainerBuilder $container)
     {
-        $customEntityManagerId = $container->getParameter('gesdinet.jwtrefreshtoken.entity_manager.id');
-        if (!$customEntityManagerId) {
+        $entityManagerId = $container->getParameter('gesdinet.jwtrefreshtoken.entity_manager.id');
+        if (!$entityManagerId) {
             return;
         }
 
-        //replace the base alias
-        $container->setAlias('gesdinet.jwtrefreshtoken.entity_manager', $customEntityManagerId);
+        $container->setAlias('gesdinet.jwtrefreshtoken.entity_manager', $entityManagerId);
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -40,8 +40,8 @@ class Configuration implements ConfigurationInterface
                     ->info('Set another refresh token entity to use instead of default one (Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken)')
                 ->end()
                 ->scalarNode('entity_manager')
-                    ->defaultNull()
-                    ->info('Set another entity manager instead of default one (doctrine.orm.entity_manager)')
+                    ->defaultValue('doctrine.orm.entity_manager')
+                    ->info('Set entity manager to use (default: doctrine.orm.entity_manager)')
                 ->end()
             ->end();
 

--- a/GesdinetJWTRefreshTokenBundle.php
+++ b/GesdinetJWTRefreshTokenBundle.php
@@ -3,7 +3,7 @@
 namespace Gesdinet\JWTRefreshTokenBundle;
 
 use Gesdinet\JWTRefreshTokenBundle\DependencyInjection\Compiler\CustomUserProviderCompilerPass;
-use Gesdinet\JWTRefreshTokenBundle\DependencyInjection\Compiler\CustomEntityManagerCompilerPass;
+use Gesdinet\JWTRefreshTokenBundle\DependencyInjection\Compiler\EntityManagerCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -14,6 +14,6 @@ class GesdinetJWTRefreshTokenBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new CustomUserProviderCompilerPass());
-        $container->addCompilerPass(new CustomEntityManagerCompilerPass());
+        $container->addCompilerPass(new EntityManagerCompilerPass());
     }
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -2,9 +2,6 @@ parameters:
   gesdinet.jwtrefreshtoken.refresh_token.class: Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken
 
 services:
-    gesdinet.jwtrefreshtoken.entity_manager:
-        alias: '@doctrine.orm.entity_manager'
-
     gesdinet.jwtrefreshtoken.send_token:
         class: Gesdinet\JWTRefreshTokenBundle\EventListener\AttachRefreshTokenOnSuccessListener
         arguments: [ "@gesdinet.jwtrefreshtoken.refresh_token_manager", "%gesdinet_jwt_refresh_token.ttl%", "@validator" ]


### PR DESCRIPTION
Hi @markitosgv,

I faced a bug caused by d72dde693ad29fe2d4209114e1b694d51706afc8

When running `app/console clear:cache`, we got the following exception:

```
Unable to replace alias "gesdinet.jwtrefreshtoken.entity_manager" with actual definition "@doctrine.orm.entity_manager"
```

This PR should fix it.