### PR TITLE
Use RequestStack rather than deprecated Lexik *Event::getRequest()

### DIFF
--- a/EventListener/AttachRefreshTokenOnSuccessListener.php
+++ b/EventListener/AttachRefreshTokenOnSuccessListener.php
@@ -17,25 +17,28 @@ use Gesdinet\JWTRefreshTokenBundle\Request\RequestRefreshToken;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\AuthenticationSuccessEvent;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class AttachRefreshTokenOnSuccessListener
 {
     protected $userRefreshTokenManager;
     protected $ttl;
     protected $validator;
+    protected $requestStack;
 
-    public function __construct(RefreshTokenManagerInterface $refreshTokenManager, $ttl, ValidatorInterface $validator)
+    public function __construct(RefreshTokenManagerInterface $refreshTokenManager, $ttl, ValidatorInterface $validator, RequestStack $requestStack)
     {
         $this->refreshTokenManager = $refreshTokenManager;
         $this->ttl = $ttl;
         $this->validator = $validator;
+        $this->requestStack = $requestStack;
     }
 
     public function attachRefreshToken(AuthenticationSuccessEvent $event)
     {
         $data = $event->getData();
         $user = $event->getUser();
-        $request = $event->getRequest();
+        $request = $this->requestStack->getCurrentRequest();
 
         if (!$user instanceof UserInterface) {
             return;

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,7 +4,7 @@ parameters:
 services:
     gesdinet.jwtrefreshtoken.send_token:
         class: Gesdinet\JWTRefreshTokenBundle\EventListener\AttachRefreshTokenOnSuccessListener
-        arguments: [ "@gesdinet.jwtrefreshtoken.refresh_token_manager", "%gesdinet_jwt_refresh_token.ttl%", "@validator" ]
+        arguments: [ "@gesdinet.jwtrefreshtoken.refresh_token_manager", "%gesdinet_jwt_refresh_token.ttl%", "@validator", "@request_stack" ]
         tags:
             - { name: kernel.event_listener, event: lexik_jwt_authentication.on_authentication_success, method: attachRefreshToken }
 


### PR DESCRIPTION
As we are deprecating all Request instances injection from our Event classes (see https://github.com/lexik/LexikJWTAuthenticationBundle/pull/200) in order to totally remove them in `lexik/jwt-authentication-bundle:2.0` (see https://github.com/lexik/LexikJWTAuthenticationBundle/pull/201), this makes this bundle working accordingly.

It would be nice to quickly move on this, as the `lexik/jwt-authentication-bundle` v2.0 will soon be released and this bundle (that is quite important for us) would not work as is.