### PR TITLE
Add a config node to change the property name of refresh token

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -31,18 +31,19 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->integerNode('ttl')->defaultValue('2592000')->end()
-                ->booleanNode('ttl_update')->defaultFalse()->end()
-                ->scalarNode('firewall')->defaultValue('api')->end()
-                ->scalarNode('user_provider')->defaultNull()->end()
-                ->scalarNode('refresh_token_entity')
-                    ->defaultNull()
-                    ->info('Set another refresh token entity to use instead of default one (Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken)')
-                ->end()
-                ->scalarNode('entity_manager')
-                    ->defaultValue('doctrine.orm.entity_manager')
-                    ->info('Set entity manager to use (default: doctrine.orm.entity_manager)')
-                ->end()
+            ->integerNode('ttl')->defaultValue('2592000')->end()
+            ->booleanNode('ttl_update')->defaultFalse()->end()
+            ->scalarNode('firewall')->defaultValue('api')->end()
+            ->scalarNode('refresh_token_property')->defaultValue('refresh_token')->end()
+            ->scalarNode('user_provider')->defaultNull()->end()
+            ->scalarNode('refresh_token_entity')
+            ->defaultNull()
+            ->info('Set another refresh token entity to use instead of default one (Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken)')
+            ->end()
+            ->scalarNode('entity_manager')
+            ->defaultValue('doctrine.orm.entity_manager')
+            ->info('Set entity manager to use (default: doctrine.orm.entity_manager)')
+            ->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/GesdinetJWTRefreshTokenExtension.php
+++ b/DependencyInjection/GesdinetJWTRefreshTokenExtension.php
@@ -37,6 +37,7 @@ class GesdinetJWTRefreshTokenExtension extends Extension
         $container->setParameter('gesdinet_jwt_refresh_token.ttl', $config['ttl']);
         $container->setParameter('gesdinet_jwt_refresh_token.ttl_update', $config['ttl_update']);
         $container->setParameter('gesdinet_jwt_refresh_token.security.firewall', $config['firewall']);
+        $container->setParameter('gesdinet_jwt_refresh_token.refresh_token_property', $config['refresh_token_property']);
         $container->setParameter('gesdinet_jwt_refresh_token.user_provider', $config['user_provider']);
 
         //if refresh_token_entity has not be defined in config, we don't want to erase base value

--- a/EventListener/AttachRefreshTokenOnSuccessListener.php
+++ b/EventListener/AttachRefreshTokenOnSuccessListener.php
@@ -23,13 +23,15 @@ class AttachRefreshTokenOnSuccessListener
 {
     protected $userRefreshTokenManager;
     protected $ttl;
+    protected $property;
     protected $validator;
     protected $requestStack;
 
-    public function __construct(RefreshTokenManagerInterface $refreshTokenManager, $ttl, ValidatorInterface $validator, RequestStack $requestStack)
+    public function __construct(RefreshTokenManagerInterface $refreshTokenManager, $ttl, $property, ValidatorInterface $validator, RequestStack $requestStack)
     {
         $this->refreshTokenManager = $refreshTokenManager;
         $this->ttl = $ttl;
+        $this->property = $property;
         $this->validator = $validator;
         $this->requestStack = $requestStack;
     }
@@ -72,7 +74,7 @@ class AttachRefreshTokenOnSuccessListener
             }
 
             $this->refreshTokenManager->save($refreshToken);
-            $data['refresh_token'] = $refreshToken->getRefreshToken();
+            $data[$this->property] = $refreshToken->getRefreshToken();
         }
 
         $event->setData($data);

--- a/EventListener/AttachRefreshTokenOnSuccessListener.php
+++ b/EventListener/AttachRefreshTokenOnSuccessListener.php
@@ -46,7 +46,7 @@ class AttachRefreshTokenOnSuccessListener
             return;
         }
 
-        $refreshTokenString = RequestRefreshToken::getRefreshToken($request);
+        $refreshTokenString = RequestRefreshToken::getRefreshToken($request, $this->property);
 
         if ($refreshTokenString) {
             $data['refresh_token'] = $refreshTokenString;

--- a/Request/RequestRefreshToken.php
+++ b/Request/RequestRefreshToken.php
@@ -15,17 +15,17 @@ use Symfony\Component\HttpFoundation\Request;
 
 class RequestRefreshToken
 {
-    public static function getRefreshToken(Request $request)
+    public static function getRefreshToken(Request $request, $property)
     {
         $refreshTokenString = null;
         if ($request->headers->get('content_type') == 'application/json') {
             $content = $request->getContent();
             $params = !empty($content) ? json_decode($content, true) : array();
-            $refreshTokenString = isset($params['refresh_token']) ? trim($params['refresh_token']) : null;
-        } elseif (null !== $request->get('refresh_token')) {
-            $refreshTokenString = $request->get('refresh_token');
-        } elseif (null !== $request->request->get('refresh_token')) {
-            $refreshTokenString = $request->request->get('refresh_token');
+            $refreshTokenString = isset($params[$property]) ? trim($params[$property]) : null;
+        } elseif (null !== $request->get($property)) {
+            $refreshTokenString = $request->get($property);
+        } elseif (null !== $request->request->get($property)) {
+            $refreshTokenString = $request->request->get($property);
         }
 
         return $refreshTokenString;

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,7 +4,7 @@ parameters:
 services:
     gesdinet.jwtrefreshtoken.send_token:
         class: Gesdinet\JWTRefreshTokenBundle\EventListener\AttachRefreshTokenOnSuccessListener
-        arguments: [ "@gesdinet.jwtrefreshtoken.refresh_token_manager", "%gesdinet_jwt_refresh_token.ttl%", "@validator", "@request_stack" ]
+        arguments: [ "@gesdinet.jwtrefreshtoken.refresh_token_manager", "%gesdinet_jwt_refresh_token.ttl%", "%gesdinet_jwt_refresh_token.refresh_token_property%", "@validator", "@request_stack" ]
         tags:
             - { name: kernel.event_listener, event: lexik_jwt_authentication.on_authentication_success, method: attachRefreshToken }
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -22,3 +22,5 @@ services:
 
     gesdinet.jwtrefreshtoken.authenticator:
         class: Gesdinet\JWTRefreshTokenBundle\Security\Authenticator\RefreshTokenAuthenticator
+        calls:
+            - [setProperty, ["%gesdinet_jwt_refresh_token.refresh_token_property%"]]

--- a/Security/Authenticator/RefreshTokenAuthenticator.php
+++ b/Security/Authenticator/RefreshTokenAuthenticator.php
@@ -36,9 +36,26 @@ if (interface_exists('Symfony\Component\Security\Http\Authentication\SimplePreAu
  */
 class RefreshTokenAuthenticator extends RefreshTokenAuthenticatorBase implements AuthenticationFailureHandlerInterface
 {
+    /**
+     * @var string
+     */
+    protected $property;
+
+    /**
+     * @param string $property
+     *
+     * @return $this
+     */
+    public function setProperty($property)
+    {
+        $this->property = $property;
+
+        return $this;
+    }
+
     public function createToken(Request $request, $providerKey)
     {
-        $refreshTokenString = RequestRefreshToken::getRefreshToken($request);
+        $refreshTokenString = RequestRefreshToken::getRefreshToken($request, $this->property);
 
         return new PreAuthenticatedToken(
             '',

--- a/spec/EventListener/AttachRefreshTokenOnSuccessListenerSpec.php
+++ b/spec/EventListener/AttachRefreshTokenOnSuccessListenerSpec.php
@@ -20,7 +20,7 @@ class AttachRefreshTokenOnSuccessListenerSpec extends ObjectBehavior
     public function let(RefreshTokenManagerInterface $refreshTokenManager, ValidatorInterface $validator, RequestStack $requestStack)
     {
         $ttl = 2592000;
-        $property = "refresh_token";
+        $property = 'refresh_token';
         $this->beConstructedWith($refreshTokenManager, $ttl, $property, $validator, $requestStack);
     }
 

--- a/spec/EventListener/AttachRefreshTokenOnSuccessListenerSpec.php
+++ b/spec/EventListener/AttachRefreshTokenOnSuccessListenerSpec.php
@@ -20,7 +20,8 @@ class AttachRefreshTokenOnSuccessListenerSpec extends ObjectBehavior
     public function let(RefreshTokenManagerInterface $refreshTokenManager, ValidatorInterface $validator, RequestStack $requestStack)
     {
         $ttl = 2592000;
-        $this->beConstructedWith($refreshTokenManager, $ttl, $validator, $requestStack);
+        $property = "refresh_token";
+        $this->beConstructedWith($refreshTokenManager, $ttl, $property, $validator, $requestStack);
     }
 
     public function it_is_initializable()

--- a/spec/Request/RequestRefreshTokenSpec.php
+++ b/spec/Request/RequestRefreshTokenSpec.php
@@ -12,7 +12,7 @@ class RequestRefreshTokenSpec extends ObjectBehavior
         $request = Request::createFromGlobals();
         $request->attributes->set('refresh_token', 'abcd');
 
-        $this::getRefreshToken($request)->shouldBe('abcd');
+        $this::getRefreshToken($request, 'refresh_token')->shouldBe('abcd');
     }
 
     public function it_gets_from_body()
@@ -20,7 +20,7 @@ class RequestRefreshTokenSpec extends ObjectBehavior
         $request = Request::createFromGlobals();
         $request->request->set('refresh_token', 'abcd');
 
-        $this::getRefreshToken($request)->shouldBe('abcd');
+        $this::getRefreshToken($request, 'refresh_token')->shouldBe('abcd');
     }
 
     public function it_gets_from_json()
@@ -28,6 +28,6 @@ class RequestRefreshTokenSpec extends ObjectBehavior
         $request = Request::create(null, 'POST', array(), array(), array(), array(), json_encode(array('refresh_token' => 'abcd')));
         $request->headers->set('content_type', 'application/json');
 
-        $this::getRefreshToken($request)->shouldBe('abcd');
+        $this::getRefreshToken($request, 'refresh_token')->shouldBe('abcd');
     }
 }

--- a/spec/Service/RefreshTokenSpec.php
+++ b/spec/Service/RefreshTokenSpec.php
@@ -45,6 +45,7 @@ class RefreshTokenSpec extends ObjectBehavior
     public function it_refresh_token_with_ttl_update(RefreshTokenProvider $provider, AuthenticationSuccessHandler $successHandler, AuthenticationFailureHandler $failureHandler, Request $request, $refreshTokenManager, $authenticator, $token, PreAuthenticatedToken $preAuthenticatedToken, RefreshTokenInterface $refreshToken)
     {
         $this->beConstructedWith($authenticator, $provider, $successHandler, $failureHandler, $refreshTokenManager, 2592000, 'testkey', true);
+        $authenticator->setProperty('refresh_token');
 
         $authenticator->createToken(Argument::any(), Argument::any())->willReturn($token);
         $authenticator->authenticateToken(Argument::any(), Argument::any(), Argument::any())->willReturn($preAuthenticatedToken);


### PR DESCRIPTION
Instead of having the "refresh_token" property hard-coded into the listener, I think it would be a good practice to use the configuration with a default value. Developers could use it to decide how to name the json node.
