### PR TITLE
use minimal symfony dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
   ],
   "require" : {
     "php": ">=5.3.3",
-    "symfony/symfony": "~2.3|~3.0",
+    "symfony/framework-bundle": "~2.3|~3.0",
+    "symfony/validator": "~2.3|~3.0",
     "doctrine/orm": "^2.4.8",
     "doctrine/doctrine-bundle": "~1.4",
     "lexik/jwt-authentication-bundle": "^1.1|^2.0@dev"


### PR DESCRIPTION
This allows to not install the whole symfony/symfony dependency as only symfony/framework-bundle and symfony/validator are required.

Required packages were found using `grep -Rh --exclude-dir=vendor --exclude-dir=bin --include='*.php' 'Symfony' | sort | uniq`.

Vendor directory is now 40MB instead of 63MB!