### PR TITLE
Set authention token after authenticating with refresh token

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -14,7 +14,7 @@ services:
 
     gesdinet.jwtrefreshtoken:
         class: Gesdinet\JWTRefreshTokenBundle\Service\RefreshToken
-        arguments: [ "@gesdinet.jwtrefreshtoken.authenticator", "@gesdinet.jwtrefreshtoken.user_provider", "@lexik_jwt_authentication.handler.authentication_success", "@lexik_jwt_authentication.handler.authentication_failure", "@gesdinet.jwtrefreshtoken.refresh_token_manager", "%gesdinet_jwt_refresh_token.ttl%", "%gesdinet_jwt_refresh_token.security.firewall%", "%gesdinet_jwt_refresh_token.ttl_update%" ]
+        arguments: [ "@gesdinet.jwtrefreshtoken.authenticator", "@gesdinet.jwtrefreshtoken.user_provider", "@security.token_storage", "@lexik_jwt_authentication.handler.authentication_success", "@lexik_jwt_authentication.handler.authentication_failure", "@gesdinet.jwtrefreshtoken.refresh_token_manager", "%gesdinet_jwt_refresh_token.ttl%", "%gesdinet_jwt_refresh_token.security.firewall%", "%gesdinet_jwt_refresh_token.ttl_update%" ]
 
     gesdinet.jwtrefreshtoken.user_provider:
         class: Gesdinet\JWTRefreshTokenBundle\Security\Provider\RefreshTokenProvider

--- a/Service/RefreshToken.php
+++ b/Service/RefreshToken.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Lexik\Bundle\JWTAuthenticationBundle\Security\Http\Authentication\AuthenticationSuccessHandler;
 use Lexik\Bundle\JWTAuthenticationBundle\Security\Http\Authentication\AuthenticationFailureHandler;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManagerInterface;
 use Gesdinet\JWTRefreshTokenBundle\Security\Authenticator\RefreshTokenAuthenticator;
 use Gesdinet\JWTRefreshTokenBundle\Security\Provider\RefreshTokenProvider;
@@ -26,16 +27,18 @@ class RefreshToken
 {
     private $authenticator;
     private $provider;
+    private $tokenStorage;
     private $successHandler;
     private $failureHandler;
     private $refreshTokenManager;
     private $ttl;
     private $ttlUpdate;
 
-    public function __construct(RefreshTokenAuthenticator $authenticator, RefreshTokenProvider $provider, AuthenticationSuccessHandler $successHandler, AuthenticationFailureHandler $failureHandler, RefreshTokenManagerInterface $refreshTokenManager, $ttl, $providerKey, $ttlUpdate)
+    public function __construct(RefreshTokenAuthenticator $authenticator, RefreshTokenProvider $provider, TokenStorageInterface $tokenStorage, AuthenticationSuccessHandler $successHandler, AuthenticationFailureHandler $failureHandler, RefreshTokenManagerInterface $refreshTokenManager, $ttl, $providerKey, $ttlUpdate)
     {
         $this->authenticator = $authenticator;
         $this->provider = $provider;
+        $this->tokenStorage = $tokenStorage;
         $this->successHandler = $successHandler;
         $this->failureHandler = $failureHandler;
         $this->refreshTokenManager = $refreshTokenManager;
@@ -79,6 +82,8 @@ class RefreshToken
 
             $this->refreshTokenManager->save($refreshToken);
         }
+
+        $this->tokenStorage->setToken($preAuthenticatedToken);
 
         return $this->successHandler->onAuthenticationSuccess($request, $preAuthenticatedToken);
     }

--- a/spec/Service/RefreshTokenSpec.php
+++ b/spec/Service/RefreshTokenSpec.php
@@ -12,18 +12,19 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 class RefreshTokenSpec extends ObjectBehavior
 {
-    public function let(RefreshTokenAuthenticator $authenticator, RefreshTokenProvider $provider, AuthenticationSuccessHandler $successHandler, AuthenticationFailureHandler $failureHandler, RefreshTokenManagerInterface $refreshTokenManager, TokenInterface $token, UserProviderInterface $userProvider, $ttl, $providerKey, $ttlUpdate)
+    public function let(RefreshTokenAuthenticator $authenticator, RefreshTokenProvider $provider, TokenStorageInterface $tokenStorage, AuthenticationSuccessHandler $successHandler, AuthenticationFailureHandler $failureHandler, RefreshTokenManagerInterface $refreshTokenManager, TokenInterface $token, UserProviderInterface $userProvider, $ttl, $providerKey, $ttlUpdate)
     {
         $ttl = 2592000;
         $ttlUpdate = false;
         $providerKey = 'testkey';
 
-        $this->beConstructedWith($authenticator, $provider, $successHandler, $failureHandler, $refreshTokenManager, $ttl, $providerKey, $ttlUpdate);
+        $this->beConstructedWith($authenticator, $provider, $tokenStorage, $successHandler, $failureHandler, $refreshTokenManager, $ttl, $providerKey, $ttlUpdate);
     }
 
     public function it_is_initializable()
@@ -42,9 +43,9 @@ class RefreshTokenSpec extends ObjectBehavior
         $this->refresh($request);
     }
 
-    public function it_refresh_token_with_ttl_update(RefreshTokenProvider $provider, AuthenticationSuccessHandler $successHandler, AuthenticationFailureHandler $failureHandler, Request $request, $refreshTokenManager, $authenticator, $token, PreAuthenticatedToken $preAuthenticatedToken, RefreshTokenInterface $refreshToken)
+    public function it_refresh_token_with_ttl_update(RefreshTokenProvider $provider, TokenStorageInterface $tokenStorage, AuthenticationSuccessHandler $successHandler, AuthenticationFailureHandler $failureHandler, Request $request, $refreshTokenManager, $authenticator, $token, PreAuthenticatedToken $preAuthenticatedToken, RefreshTokenInterface $refreshToken)
     {
-        $this->beConstructedWith($authenticator, $provider, $successHandler, $failureHandler, $refreshTokenManager, 2592000, 'testkey', true);
+        $this->beConstructedWith($authenticator, $provider, $tokenStorage, $successHandler, $failureHandler, $refreshTokenManager, 2592000, 'testkey', true);
 
         $authenticator->createToken(Argument::any(), Argument::any())->willReturn($token);
         $authenticator->authenticateToken(Argument::any(), Argument::any(), Argument::any())->willReturn($preAuthenticatedToken);


### PR DESCRIPTION
This PR sets the correct security token in the token_storage after authenticating with a refresh token. This allows services that run after authentication (e.g event handlers that listen to onAuthenticationSuccess) to use Symfony services like the authorization_checker.