### PR TITLE
Match full variety of Content-Type values

### DIFF
--- a/Request/RequestRefreshToken.php
+++ b/Request/RequestRefreshToken.php
@@ -18,7 +18,7 @@ class RequestRefreshToken
     public static function getRefreshToken(Request $request)
     {
         $refreshTokenString = null;
-        if (0 === strpos($request->getContentType(), 'application/json')) {
+        if (false !== strpos($request->getContentType(), 'json')) {
             $content = $request->getContent();
             $params = !empty($content) ? json_decode($content, true) : array();
             $refreshTokenString = isset($params['refresh_token']) ? trim($params['refresh_token']) : null;

--- a/Request/RequestRefreshToken.php
+++ b/Request/RequestRefreshToken.php
@@ -18,7 +18,7 @@ class RequestRefreshToken
     public static function getRefreshToken(Request $request)
     {
         $refreshTokenString = null;
-        if ($request->headers->get('content_type') == 'application/json') {
+        if (0 === strpos($request->getContentType(), 'application/json')) {
             $content = $request->getContent();
             $params = !empty($content) ? json_decode($content, true) : array();
             $refreshTokenString = isset($params['refresh_token']) ? trim($params['refresh_token']) : null;

--- a/spec/Request/RequestRefreshTokenSpec.php
+++ b/spec/Request/RequestRefreshTokenSpec.php
@@ -30,4 +30,20 @@ class RequestRefreshTokenSpec extends ObjectBehavior
 
         $this::getRefreshToken($request)->shouldBe('abcd');
     }
+
+    public function it_gets_from_json_x()
+    {
+        $request = Request::create(null, 'POST', array(), array(), array(), array(), json_encode(array('refresh_token' => 'abcd')));
+        $request->headers->set('content_type', 'application/x-json');
+
+        $this::getRefreshToken($request)->shouldBe('abcd');
+    }
+
+    public function it_gets_from_json_parameter()
+    {
+        $request = Request::create(null, 'POST', array(), array(), array(), array(), json_encode(array('refresh_token' => 'abcd')));
+        $request->headers->set('content_type', 'application/json;charset=UTF-8');
+
+        $this::getRefreshToken($request)->shouldBe('abcd');
+    }
 }


### PR DESCRIPTION
At the moment the "Content-Type" header must be exactly 'application/json' for the refresh token to be extracted from the request when it is in json format.

It is valid for "Content-Type" header to have a parameter for example 'application/json;charset=UTF-8', but this does not match the criteria and so the refresh fails. (https://www.w3.org/Protocols/rfc1341/4_Content-Type.html)

This change borrows logic from here: https://github.com/symfony/symfony/blob/4427cf9157d5d896e2221a31afeac293f2ad9971/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordJsonAuthenticationListener.php#L79 in order to check if the incoming request is in json format. 

This means that content types with parameters will be accepted. Also both 'application/json' & 'application/x-json' are considered by Symfony to be json, this is the code that determines it: https://github.com/symfony/symfony/blob/4bd7b921f4047fa32478459a9b50e63001372aee/src/Symfony/Component/HttpFoundation/Request.php#L1851