### PR TITLE
Create AbstractRefreshToken to allow custom RefreshToken entities

### DIFF
--- a/Entity/AbstractRefreshToken.php
+++ b/Entity/AbstractRefreshToken.php
@@ -1,0 +1,152 @@
+<?php
+
+/*
+ * This file is part of the GesdinetJWTRefreshTokenBundle package.
+ *
+ * (c) Gesdinet <http://www.gesdinet.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gesdinet\JWTRefreshTokenBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
+use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+
+/**
+ * Abstract Refresh Token.
+ *
+ * @ORM\MappedSuperclass()
+ * @UniqueEntity("refreshToken")
+ */
+abstract class AbstractRefreshToken implements RefreshTokenInterface
+{
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="refresh_token", type="string", length=128, unique=true)
+     * @Assert\NotBlank()
+     */
+    private $refreshToken;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="username", type="string", length=255)
+     * @Assert\NotBlank()
+     */
+    private $username;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="valid", type="datetime")
+     * @Assert\NotBlank()
+     */
+    private $valid;
+
+    /**
+     * {@inheritdoc}
+     */
+    abstract public function getId();
+
+    /**
+     * Set refreshToken.
+     *
+     * @param string $refreshToken
+     *
+     * @return RefreshToken
+     */
+    public function setRefreshToken($refreshToken = null)
+    {
+        if (null == $refreshToken) {
+            $this->refreshToken = bin2hex(openssl_random_pseudo_bytes(64));
+        } else {
+            $this->refreshToken = $refreshToken;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get refreshToken.
+     *
+     * @return string
+     */
+    public function getRefreshToken()
+    {
+        return $this->refreshToken;
+    }
+
+    /**
+     * Set valid.
+     *
+     * @param \DateTime $valid
+     *
+     * @return RefreshToken
+     */
+    public function setValid($valid)
+    {
+        $this->valid = $valid;
+
+        return $this;
+    }
+
+    /**
+     * Get valid.
+     *
+     * @return \DateTime
+     */
+    public function getValid()
+    {
+        return $this->valid;
+    }
+
+    /**
+     * Set username.
+     *
+     * @param string $username
+     *
+     * @return RefreshToken
+     */
+    public function setUsername($username)
+    {
+        $this->username = $username;
+
+        return $this;
+    }
+
+    /**
+     * Get username.
+     *
+     * @return string
+     */
+    public function getUsername()
+    {
+        return $this->username;
+    }
+
+    /**
+     * Check if is a valid refresh token.
+     *
+     * @return bool
+     */
+    public function isValid()
+    {
+        $datetime = new \DateTime();
+
+        return ($this->valid >= $datetime) ? true : false;
+    }
+
+    /**
+     * @return string Refresh Token
+     */
+    public function __toString()
+    {
+        return $this->getRefreshToken();
+    }
+}

--- a/Entity/RefreshToken.php
+++ b/Entity/RefreshToken.php
@@ -23,7 +23,7 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
  * @ORM\Entity(repositoryClass="Gesdinet\JWTRefreshTokenBundle\Entity\RefreshTokenRepository")
  * @UniqueEntity("refreshToken")
  */
-class RefreshToken implements RefreshTokenInterface
+class RefreshToken extends AbstractRefreshToken
 {
     /**
      * @var int
@@ -35,132 +35,10 @@ class RefreshToken implements RefreshTokenInterface
     protected $id;
 
     /**
-     * @var string
-     *
-     * @ORM\Column(name="refresh_token", type="string", length=128, unique=true)
-     * @Assert\NotBlank()
-     */
-    protected $refreshToken;
-
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="username", type="string", length=255)
-     * @Assert\NotBlank()
-     */
-    protected $username;
-
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="valid", type="datetime")
-     * @Assert\NotBlank()
-     */
-    protected $valid;
-
-    /**
-     * Get id.
-     *
-     * @return int
+     * {@inheritdoc}
      */
     public function getId()
     {
-        return $this->id;
-    }
-
-    /**
-     * Set refreshToken.
-     *
-     * @param string $refreshToken
-     *
-     * @return RefreshToken
-     */
-    public function setRefreshToken($refreshToken = null)
-    {
-        if (null == $refreshToken) {
-            $this->refreshToken = bin2hex(openssl_random_pseudo_bytes(64));
-        } else {
-            $this->refreshToken = $refreshToken;
-        }
-
-        return $this;
-    }
-
-    /**
-     * Get refreshToken.
-     *
-     * @return string
-     */
-    public function getRefreshToken()
-    {
-        return $this->refreshToken;
-    }
-
-    /**
-     * Set valid.
-     *
-     * @param \DateTime $valid
-     *
-     * @return RefreshToken
-     */
-    public function setValid($valid)
-    {
-        $this->valid = $valid;
-
-        return $this;
-    }
-
-    /**
-     * Get valid.
-     *
-     * @return \DateTime
-     */
-    public function getValid()
-    {
-        return $this->valid;
-    }
-
-    /**
-     * Set username.
-     *
-     * @param string $username
-     *
-     * @return RefreshToken
-     */
-    public function setUsername($username)
-    {
-        $this->username = $username;
-
-        return $this;
-    }
-
-    /**
-     * Get username.
-     *
-     * @return string
-     */
-    public function getUsername()
-    {
-        return $this->username;
-    }
-
-    /**
-     * Check if is a valid refresh token.
-     *
-     * @return bool
-     */
-    public function isValid()
-    {
-        $datetime = new \DateTime();
-
-        return ($this->valid >= $datetime) ? true : false;
-    }
-
-    /**
-     * @return string Refresh Token
-     */
-    public function __toString()
-    {
-        return $this->getRefreshToken();
+        $this->id;
     }
 }

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Create the entity class extending `Gesdinet\JWTRefreshTokenBundle\Entity\Refresh
 ```php
 namespace MyBundle;
 
-use Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken as BaseRefreshToken;
+use Gesdinet\JWTRefreshTokenBundle\Entity\AbstractRefreshToken;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -160,8 +160,20 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity(repositoryClass="Gesdinet\JWTRefreshTokenBundle\Entity\RefreshTokenRepository")
  * @UniqueEntity("refreshToken")
  */
-class JwtRefreshToken extends BaseRefreshToken
+class JwtRefreshToken extends AbstractRefreshToken
 {
+    /**
+     * @var string
+     */
+    protected $id;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getId()
+    {
+        $this->id;
+    }
 }
 ```
 


### PR DESCRIPTION
This PR fixes #70.

In the current implementation, if someone creates a custom `EntityToken` entity, the table `refresh_tokens` will also be created but no used. If you want I can provide a compiler pass to add the Doctrine mapping for `RefreshToken` based on `gesdinet_jwt_refresh_token.refresh_token_entity`. It will fix #51.