### PR TITLE
Add support for parameter naming strategies

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -43,6 +43,10 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue('doctrine.orm.entity_manager')
                     ->info('Set entity manager to use (default: doctrine.orm.entity_manager)')
                 ->end()
+                ->scalarNode('parameter_name_generator')
+                    ->defaultValue('gesdinet.jwtrefreshtoken.name_generator.underscore')
+                    ->info('Set service used to generate the parameter name in requests and responses (default: gesdinet.jwtrefreshtoken.name_generator.underscore)')
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/GesdinetJWTRefreshTokenExtension.php
+++ b/DependencyInjection/GesdinetJWTRefreshTokenExtension.php
@@ -11,10 +11,11 @@
 
 namespace Gesdinet\JWTRefreshTokenBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * This is the class that loads and manages your bundle configuration.
@@ -45,5 +46,13 @@ class GesdinetJWTRefreshTokenExtension extends Extension
         }
 
         $container->setParameter('gesdinet.jwtrefreshtoken.entity_manager.id', $config['entity_manager']);
+
+        /** @var string $nameGeneratorServiceDefinition */
+        $nameGeneratorServiceDefinition = $config['parameter_name_generator'];
+        if (!$container->has($nameGeneratorServiceDefinition)) {
+            throw new ServiceNotFoundException($nameGeneratorServiceDefinition);
+        }
+
+        $container->setAlias('gesdinet.jwtrefreshtoken.name_generator.default', $nameGeneratorServiceDefinition);
     }
 }

--- a/Doctrine/RefreshTokenManager.php
+++ b/Doctrine/RefreshTokenManager.php
@@ -18,7 +18,9 @@ use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
 class RefreshTokenManager extends BaseRefreshTokenManager
 {
     protected $objectManager;
+
     protected $class;
+
     protected $repository;
 
     /**

--- a/EventListener/AttachRefreshTokenOnSuccessListener.php
+++ b/EventListener/AttachRefreshTokenOnSuccessListener.php
@@ -22,7 +22,6 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class AttachRefreshTokenOnSuccessListener
 {
-
     /**
      * @var NameGeneratorInterface
      */
@@ -33,6 +32,9 @@ class AttachRefreshTokenOnSuccessListener
      */
     private $refreshTokenManager;
 
+    /**
+     * @var int
+     */
     private $ttl;
 
     /**
@@ -50,9 +52,8 @@ class AttachRefreshTokenOnSuccessListener
      */
     private $requestStack;
 
-
     /**
-     * Injects dependencies
+     * Injects dependencies.
      *
      * @param RefreshTokenManagerInterface $refreshTokenManager
      * @param                              $ttl

--- a/NameGenerator/CamelCaseNameGenerator.php
+++ b/NameGenerator/CamelCaseNameGenerator.php
@@ -5,9 +5,7 @@ namespace Gesdinet\JWTRefreshTokenBundle\NameGenerator;
 use Doctrine\Common\Inflector\Inflector;
 
 /**
- * Class CamelCaseNameGenerator
- *
- * @package Gesdinet\JWTRefreshTokenBundle\NameGenerator
+ * Name generator for camel case names.
  *
  * @see CamelCaseNameGeneratorSpec for unit tests
  */

--- a/NameGenerator/CamelCaseNameGenerator.php
+++ b/NameGenerator/CamelCaseNameGenerator.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types = 1);
+
+namespace Gesdinet\JWTRefreshTokenBundle\NameGenerator;
+
+use Doctrine\Common\Inflector\Inflector;
+
+/**
+ * Class CamelCaseNameGenerator
+ *
+ * @package Gesdinet\JWTRefreshTokenBundle\NameGenerator
+ *
+ * @see CamelCaseNameGeneratorSpec for unit tests
+ */
+class CamelCaseNameGenerator implements NameGeneratorInterface
+{
+    /**
+     * @param string $name
+     *
+     * @return string
+     */
+    public function generateName($name)
+    {
+        return Inflector::camelize($name);
+    }
+}

--- a/NameGenerator/CamelCaseNameGenerator.php
+++ b/NameGenerator/CamelCaseNameGenerator.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types = 1);
 
 namespace Gesdinet\JWTRefreshTokenBundle\NameGenerator;
 

--- a/NameGenerator/NameGeneratorInterface.php
+++ b/NameGenerator/NameGeneratorInterface.php
@@ -3,15 +3,13 @@
 namespace Gesdinet\JWTRefreshTokenBundle\NameGenerator;
 
 /**
- * Interface for parameter nameing generators
- *
- * @package Gesdinet\JWTRefreshTokenBundle
+ * Interface for parameter naming generators.
  */
 interface NameGeneratorInterface
 {
 
     /**
-     * Convert the given name to the generator's styled version
+     * Convert the given name to the generator's styled version.
      *
      * @param string $name
      *

--- a/NameGenerator/NameGeneratorInterface.php
+++ b/NameGenerator/NameGeneratorInterface.php
@@ -7,7 +7,6 @@ namespace Gesdinet\JWTRefreshTokenBundle\NameGenerator;
  */
 interface NameGeneratorInterface
 {
-
     /**
      * Convert the given name to the generator's styled version.
      *

--- a/NameGenerator/NameGeneratorInterface.php
+++ b/NameGenerator/NameGeneratorInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Gesdinet\JWTRefreshTokenBundle\NameGenerator;
+
+/**
+ * Interface for parameter nameing generators
+ *
+ * @package Gesdinet\JWTRefreshTokenBundle
+ */
+interface NameGeneratorInterface
+{
+
+    /**
+     * Convert the given name to the generator's styled version
+     *
+     * @param string $name
+     *
+     * @return string
+     */
+    public function generateName($name);
+}

--- a/NameGenerator/UnderscoreNameGenerator.php
+++ b/NameGenerator/UnderscoreNameGenerator.php
@@ -5,9 +5,7 @@ namespace Gesdinet\JWTRefreshTokenBundle\NameGenerator;
 use Doctrine\Common\Inflector\Inflector;
 
 /**
- * Class UnderscoreNameGenerator
- *
- * @package Gesdinet\JWTRefreshTokenBundle\NameGenerator
+ * Name generator for underscore names.
  *
  * @see UnderscoreNameGeneratorSpec for unit tests
  */

--- a/NameGenerator/UnderscoreNameGenerator.php
+++ b/NameGenerator/UnderscoreNameGenerator.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Gesdinet\JWTRefreshTokenBundle\NameGenerator;
+
+use Doctrine\Common\Inflector\Inflector;
+
+/**
+ * Class UnderscoreNameGenerator
+ *
+ * @package Gesdinet\JWTRefreshTokenBundle\NameGenerator
+ *
+ * @see UnderscoreNameGeneratorSpec for unit tests
+ */
+class UnderscoreNameGenerator implements NameGeneratorInterface
+{
+    /**
+     * @param string $name
+     *
+     * @return string
+     */
+    public function generateName($name)
+    {
+        return Inflector::tableize($name);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -183,6 +183,27 @@ gesdinet_jwt_refresh_token:
     entity_manager: my.specific.entity_manager.id
 ```
 
+### Use change the format of the 'refresh_token' parameter
+
+You can tell JWTRefreshTokenBundle to use another naming strategy for the 'refresh_token' parameter.  By default this 
+uses the underscore notation, but you can configure it to use any of the provided name generators, or your own custom 
+one.
+
+Just add this line to your config.yml file:
+
+```yaml
+gesdinet_jwt_refresh_token:
+    parameter_name_generator: gesdinet.jwtrefreshtoken.name_generator.camel_case
+```
+
+Provided name generators…
+
+* gesdinet.jwtrefreshtoken.name_generator.underscore
+* gesdinet.jwtrefreshtoken.name_generator.camel_case
+
+If you would like to provide your own, simply register a service that extends  
+\Gesdinet\JWTRefreshTokenBundle\NameGenerator\NameGeneratorInterface, and use this in the config value.
+
 ### Generating Tokens
 
 When you authenticate through /api/login_check with user/password credentials, LexikJWTAuthenticationBundle now returns a JWT Token and a Refresh Token data.

--- a/Request/RequestRefreshToken.php
+++ b/Request/RequestRefreshToken.php
@@ -15,9 +15,7 @@ use Gesdinet\JWTRefreshTokenBundle\NameGenerator\NameGeneratorInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * Class RequestRefreshToken
- *
- * @package Gesdinet\JWTRefreshTokenBundle
+ * Service to extract refresh token from a request object.
  */
 class RequestRefreshToken
 {
@@ -28,7 +26,7 @@ class RequestRefreshToken
 
 
     /**
-     * Injects dependencies
+     * Injects dependencies.
      *
      * @param NameGeneratorInterface $nameGenerator
      */
@@ -41,7 +39,7 @@ class RequestRefreshToken
     public function getRefreshToken(Request $request)
     {
         $refreshTokenString = null;
-        $refreshTokenName   = $this->getRefreshTokenName();
+        $refreshTokenName = $this->getRefreshTokenName();
 
         if (false !== strpos($request->getContentType(), 'json')) {
             $content = $request->getContent();
@@ -58,7 +56,7 @@ class RequestRefreshToken
 
 
     /**
-     * Returns the name of the access token based on the current naming convention
+     * Returns the name of the access token based on the current naming convention.
      *
      * @return string
      */

--- a/Request/RequestRefreshToken.php
+++ b/Request/RequestRefreshToken.php
@@ -24,7 +24,6 @@ class RequestRefreshToken
      */
     private $nameGenerator;
 
-
     /**
      * Injects dependencies.
      *
@@ -34,7 +33,6 @@ class RequestRefreshToken
     {
         $this->nameGenerator = $nameGenerator;
     }
-
 
     public function getRefreshToken(Request $request)
     {
@@ -53,7 +51,6 @@ class RequestRefreshToken
 
         return $refreshTokenString;
     }
-
 
     /**
      * Returns the name of the access token based on the current naming convention.

--- a/Request/RequestRefreshToken.php
+++ b/Request/RequestRefreshToken.php
@@ -11,23 +11,59 @@
 
 namespace Gesdinet\JWTRefreshTokenBundle\Request;
 
+use Gesdinet\JWTRefreshTokenBundle\NameGenerator\NameGeneratorInterface;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * Class RequestRefreshToken
+ *
+ * @package Gesdinet\JWTRefreshTokenBundle
+ */
 class RequestRefreshToken
 {
-    public static function getRefreshToken(Request $request)
+    /**
+     * @var NameGeneratorInterface
+     */
+    private $nameGenerator;
+
+
+    /**
+     * Injects dependencies
+     *
+     * @param NameGeneratorInterface $nameGenerator
+     */
+    public function __construct(NameGeneratorInterface $nameGenerator)
+    {
+        $this->nameGenerator = $nameGenerator;
+    }
+
+
+    public function getRefreshToken(Request $request)
     {
         $refreshTokenString = null;
+        $refreshTokenName   = $this->getRefreshTokenName();
+
         if (false !== strpos($request->getContentType(), 'json')) {
             $content = $request->getContent();
             $params = !empty($content) ? json_decode($content, true) : array();
-            $refreshTokenString = isset($params['refresh_token']) ? trim($params['refresh_token']) : null;
-        } elseif (null !== $request->get('refresh_token')) {
-            $refreshTokenString = $request->get('refresh_token');
-        } elseif (null !== $request->request->get('refresh_token')) {
-            $refreshTokenString = $request->request->get('refresh_token');
+            $refreshTokenString = isset($params[$refreshTokenName]) ? trim($params[$refreshTokenName]) : null;
+        } elseif (null !== $request->get($refreshTokenName)) {
+            $refreshTokenString = $request->get($refreshTokenName);
+        } elseif (null !== $request->request->get($refreshTokenName)) {
+            $refreshTokenString = $request->request->get($refreshTokenName);
         }
 
         return $refreshTokenString;
+    }
+
+
+    /**
+     * Returns the name of the access token based on the current naming convention
+     *
+     * @return string
+     */
+    private function getRefreshTokenName()
+    {
+        return $this->nameGenerator->generateName('refresh_token');
     }
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -26,6 +26,7 @@ services:
 
     gesdinet.jwtrefreshtoken.authenticator:
         class: Gesdinet\JWTRefreshTokenBundle\Security\Authenticator\RefreshTokenAuthenticator
+        arguments: [ "@gesdinet.jwtrefreshtoken.request_refresh_token" ]
 
     gesdinet.jwtrefreshtoken.name_generator.default:
         # This is overridden in GesdinetJWTRefreshTokenExtension based on user config

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -28,6 +28,7 @@ services:
         class: Gesdinet\JWTRefreshTokenBundle\Security\Authenticator\RefreshTokenAuthenticator
 
     gesdinet.jwtrefreshtoken.name_generator.default:
+        # This is overridden in GesdinetJWTRefreshTokenExtension based on user config
         alias: gesdinet.jwtrefreshtoken.name_generator.underscore
         public: false
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -22,3 +22,15 @@ services:
 
     gesdinet.jwtrefreshtoken.authenticator:
         class: Gesdinet\JWTRefreshTokenBundle\Security\Authenticator\RefreshTokenAuthenticator
+
+    gesdinet.jwtrefreshtoken.name_generator.default:
+        alias: gesdinet.jwtrefreshtoken.name_generator.underscore
+        public: false
+
+    gesdinet.jwtrefreshtoken.name_generator.underscore:
+        class: Gesdinet\JWTRefreshTokenBundle\NameGenerator\UnderscoreNameGenerator
+        public: false
+
+    gesdinet.jwtrefreshtoken.name_generator.camel_case:
+        class: Gesdinet\JWTRefreshTokenBundle\NameGenerator\CamelCaseNameGenerator
+        public: false

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -30,12 +30,9 @@ services:
     gesdinet.jwtrefreshtoken.name_generator.default:
         # This is overridden in GesdinetJWTRefreshTokenExtension based on user config
         alias: gesdinet.jwtrefreshtoken.name_generator.underscore
-        public: false
 
     gesdinet.jwtrefreshtoken.name_generator.underscore:
         class: Gesdinet\JWTRefreshTokenBundle\NameGenerator\UnderscoreNameGenerator
-        public: false
 
     gesdinet.jwtrefreshtoken.name_generator.camel_case:
         class: Gesdinet\JWTRefreshTokenBundle\NameGenerator\CamelCaseNameGenerator
-        public: false

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -12,6 +12,10 @@ services:
         class: Gesdinet\JWTRefreshTokenBundle\Doctrine\RefreshTokenManager
         arguments: [ "@gesdinet.jwtrefreshtoken.entity_manager", "%gesdinet.jwtrefreshtoken.refresh_token.class%" ]
 
+    gesdinet.jwtrefreshtoken.request_refresh_token:
+        class: Gesdinet\JWTRefreshTokenBundle\Request\RequestRefreshToken
+        arguments: [ "@gesdinet.jwtrefreshtoken.name_generator.default" ]
+
     gesdinet.jwtrefreshtoken:
         class: Gesdinet\JWTRefreshTokenBundle\Service\RefreshToken
         arguments: [ "@gesdinet.jwtrefreshtoken.authenticator", "@gesdinet.jwtrefreshtoken.user_provider", "@lexik_jwt_authentication.handler.authentication_success", "@lexik_jwt_authentication.handler.authentication_failure", "@gesdinet.jwtrefreshtoken.refresh_token_manager", "%gesdinet_jwt_refresh_token.ttl%", "%gesdinet_jwt_refresh_token.security.firewall%", "%gesdinet_jwt_refresh_token.ttl_update%" ]

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,7 +4,7 @@ parameters:
 services:
     gesdinet.jwtrefreshtoken.send_token:
         class: Gesdinet\JWTRefreshTokenBundle\EventListener\AttachRefreshTokenOnSuccessListener
-        arguments: [ "@gesdinet.jwtrefreshtoken.refresh_token_manager", "%gesdinet_jwt_refresh_token.ttl%", "@validator", "@request_stack" ]
+        arguments: [ "@gesdinet.jwtrefreshtoken.refresh_token_manager", "%gesdinet_jwt_refresh_token.ttl%", "@validator", "@request_stack", "@gesdinet.jwtrefreshtoken.request_refresh_token", "@gesdinet.jwtrefreshtoken.name_generator.default" ]
         tags:
             - { name: kernel.event_listener, event: lexik_jwt_authentication.on_authentication_success, method: attachRefreshToken }
 

--- a/Security/Authenticator/RefreshTokenAuthenticator.php
+++ b/Security/Authenticator/RefreshTokenAuthenticator.php
@@ -36,9 +36,24 @@ if (interface_exists('Symfony\Component\Security\Http\Authentication\SimplePreAu
  */
 class RefreshTokenAuthenticator extends RefreshTokenAuthenticatorBase implements AuthenticationFailureHandlerInterface
 {
+    /**
+     * @var RequestRefreshToken
+     */
+    private $requestRefreshToken;
+
+    /**
+     * Injects dependencies.
+     *
+     * @param RequestRefreshToken $requestRefreshToken
+     */
+    public function __construct(RequestRefreshToken $requestRefreshToken)
+    {
+        $this->requestRefreshToken = $requestRefreshToken;
+    }
+
     public function createToken(Request $request, $providerKey)
     {
-        $refreshTokenString = RequestRefreshToken::getRefreshToken($request);
+        $refreshTokenString = $this->requestRefreshToken->getRefreshToken($request);
 
         return new PreAuthenticatedToken(
             '',

--- a/Security/Provider/RefreshTokenProvider.php
+++ b/Security/Provider/RefreshTokenProvider.php
@@ -49,7 +49,7 @@ class RefreshTokenProvider implements UserProviderInterface
 
     public function loadUserByUsername($username)
     {
-        if ($this->customUserProvider != null) {
+        if (null != $this->customUserProvider) {
             return $this->customUserProvider->loadUserByUsername($username);
         } else {
             return new User(
@@ -62,7 +62,7 @@ class RefreshTokenProvider implements UserProviderInterface
 
     public function refreshUser(UserInterface $user)
     {
-        if ($this->customUserProvider != null) {
+        if (null != $this->customUserProvider) {
             return $this->customUserProvider->refreshUser($user);
         } else {
             throw new UnsupportedUserException();
@@ -71,7 +71,7 @@ class RefreshTokenProvider implements UserProviderInterface
 
     public function supportsClass($class)
     {
-        if ($this->customUserProvider != null) {
+        if (null != $this->customUserProvider) {
             return $this->customUserProvider->supportsClass($class);
         } else {
             return 'Symfony\Component\Security\Core\User\User' === $class;

--- a/Security/Provider/RefreshTokenProvider.php
+++ b/Security/Provider/RefreshTokenProvider.php
@@ -24,6 +24,7 @@ use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
 class RefreshTokenProvider implements UserProviderInterface
 {
     protected $refreshTokenManager;
+
     protected $customUserProvider;
 
     public function __construct(RefreshTokenManagerInterface $refreshTokenManager)

--- a/Service/RefreshToken.php
+++ b/Service/RefreshToken.php
@@ -66,7 +66,6 @@ class RefreshToken
      */
     private $ttlUpdate;
 
-
     public function __construct(RefreshTokenAuthenticator $authenticator, RefreshTokenProvider $provider, AuthenticationSuccessHandler $successHandler, AuthenticationFailureHandler $failureHandler, RefreshTokenManagerInterface $refreshTokenManager, $ttl, $providerKey, $ttlUpdate)
     {
         $this->authenticator = $authenticator;

--- a/Service/RefreshToken.php
+++ b/Service/RefreshToken.php
@@ -24,13 +24,48 @@ use Gesdinet\JWTRefreshTokenBundle\Security\Provider\RefreshTokenProvider;
  */
 class RefreshToken
 {
+    /**
+     * @var RefreshTokenAuthenticator
+     */
     private $authenticator;
+
+    /**
+     * @var RefreshTokenProvider
+     */
     private $provider;
+
+    /**
+     * @var AuthenticationSuccessHandler
+     */
     private $successHandler;
+
+    /**
+     * @var AuthenticationFailureHandler
+     */
     private $failureHandler;
+
+    /**
+     * @var RefreshTokenManagerInterface
+     */
     private $refreshTokenManager;
+
+    /**
+     * @var
+     */
     private $ttl;
+
+    /**
+     * @var string
+     */
+    private $providerKey;
+
+    /**
+     * Whether the refresh token valid date time should be updated when refreshing.
+     *
+     * @var bool
+     */
     private $ttlUpdate;
+
 
     public function __construct(RefreshTokenAuthenticator $authenticator, RefreshTokenProvider $provider, AuthenticationSuccessHandler $successHandler, AuthenticationFailureHandler $failureHandler, RefreshTokenManagerInterface $refreshTokenManager, $ttl, $providerKey, $ttlUpdate)
     {

--- a/spec/DependencyInjection/GesdinetJWTRefreshTokenExtensionSpec.php
+++ b/spec/DependencyInjection/GesdinetJWTRefreshTokenExtensionSpec.php
@@ -2,12 +2,10 @@
 
 namespace spec\Gesdinet\JWTRefreshTokenBundle\DependencyInjection;
 
-use Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 class GesdinetJWTRefreshTokenExtensionSpec extends ObjectBehavior
 {

--- a/spec/DependencyInjection/GesdinetJWTRefreshTokenExtensionSpec.php
+++ b/spec/DependencyInjection/GesdinetJWTRefreshTokenExtensionSpec.php
@@ -2,7 +2,9 @@
 
 namespace spec\Gesdinet\JWTRefreshTokenBundle\DependencyInjection;
 
+use Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken;
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class GesdinetJWTRefreshTokenExtensionSpec extends ObjectBehavior
@@ -12,9 +14,30 @@ class GesdinetJWTRefreshTokenExtensionSpec extends ObjectBehavior
         $this->shouldHaveType('Gesdinet\JWTRefreshTokenBundle\DependencyInjection\GesdinetJWTRefreshTokenExtension');
     }
 
+
     public function it_should_set_parameters_correctly(ContainerBuilder $container)
     {
-        $configs = array();
+        $container->fileExists(dirname(dirname(__DIR__)).'/DependencyInjection/../Resources/config/services.yml')
+                  ->willReturn(true);
+
+        // setParameter calls with default values
+        $container->setParameter('gesdinet_jwt_refresh_token.ttl', 2592000)
+                  ->shouldBeCalled();
+        $container->setParameter('gesdinet_jwt_refresh_token.ttl_update', false)
+                  ->shouldBeCalled();
+        $container->setParameter('gesdinet_jwt_refresh_token.security.firewall', 'api')
+                  ->shouldBeCalled();
+        $container->setParameter('gesdinet_jwt_refresh_token.user_provider', null)
+                  ->shouldBeCalled();
+        $container->setParameter('gesdinet.jwtrefreshtoken.refresh_token.class', RefreshToken::class)
+                  ->shouldBeCalled();
+        $container->setParameter('gesdinet.jwtrefreshtoken.entity_manager.id', 'doctrine.orm.entity_manager')
+                  ->shouldBeCalled();
+
+        $container->setDefinition(Argument::cetera())
+                  ->willReturn();
+
+        $configs = [];
         $this->load($configs, $container);
     }
 }

--- a/spec/DependencyInjection/GesdinetJWTRefreshTokenExtensionSpec.php
+++ b/spec/DependencyInjection/GesdinetJWTRefreshTokenExtensionSpec.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 class GesdinetJWTRefreshTokenExtensionSpec extends ObjectBehavior
 {
-    function let(ContainerBuilder $container)
+    public function let(ContainerBuilder $container)
     {
         $container->fileExists(dirname(dirname(__DIR__)).'/DependencyInjection/../Resources/config/services.yml')
                   ->willReturn(true);
@@ -19,12 +19,10 @@ class GesdinetJWTRefreshTokenExtensionSpec extends ObjectBehavior
                   ->willReturn(true);
     }
 
-
     public function it_is_initializable()
     {
         $this->shouldHaveType('Gesdinet\JWTRefreshTokenBundle\DependencyInjection\GesdinetJWTRefreshTokenExtension');
     }
-
 
     public function it_should_set_parameters_correctly(ContainerBuilder $container)
     {
@@ -54,8 +52,7 @@ class GesdinetJWTRefreshTokenExtensionSpec extends ObjectBehavior
         $this->load($configs, $container);
     }
 
-
-    function it_should_configure_the_default_naming_generator(ContainerBuilder $container)
+    public function it_should_configure_the_default_naming_generator(ContainerBuilder $container)
     {
         $container->setAlias(
             'gesdinet.jwtrefreshtoken.name_generator.default',
@@ -73,8 +70,7 @@ class GesdinetJWTRefreshTokenExtensionSpec extends ObjectBehavior
         $this->load($configs, $container);
     }
 
-
-    function it_should_throw_an_exception_if_specifying_a_non_existent_name_generator_service(
+    public function it_should_throw_an_exception_if_specifying_a_non_existent_name_generator_service(
         ContainerBuilder $container
     ) {
         $container->has('some.service.name')
@@ -93,8 +89,7 @@ class GesdinetJWTRefreshTokenExtensionSpec extends ObjectBehavior
              ->during('load', [$configs, $container]);
     }
 
-
-    function it_should_configure_a_custom_name_generator(ContainerBuilder $container)
+    public function it_should_configure_a_custom_name_generator(ContainerBuilder $container)
     {
         // Expectations
         $container->setAlias('gesdinet.jwtrefreshtoken.name_generator.default', 'some.service.name')

--- a/spec/DependencyInjection/GesdinetJWTRefreshTokenExtensionSpec.php
+++ b/spec/DependencyInjection/GesdinetJWTRefreshTokenExtensionSpec.php
@@ -34,7 +34,10 @@ class GesdinetJWTRefreshTokenExtensionSpec extends ObjectBehavior
         $container->setParameter('gesdinet.jwtrefreshtoken.entity_manager.id', 'doctrine.orm.entity_manager')
                   ->shouldBeCalled();
 
+        // Ignore these calls
         $container->setDefinition(Argument::cetera())
+                  ->willReturn();
+        $container->setAlias(Argument::cetera())
                   ->willReturn();
 
         $configs = [];

--- a/spec/DependencyInjection/GesdinetJWTRefreshTokenExtensionSpec.php
+++ b/spec/DependencyInjection/GesdinetJWTRefreshTokenExtensionSpec.php
@@ -35,7 +35,7 @@ class GesdinetJWTRefreshTokenExtensionSpec extends ObjectBehavior
                   ->shouldBeCalled();
         $container->setParameter('gesdinet_jwt_refresh_token.user_provider', null)
                   ->shouldBeCalled();
-        $container->setParameter('gesdinet.jwtrefreshtoken.refresh_token.class', RefreshToken::class)
+        $container->setParameter('gesdinet.jwtrefreshtoken.refresh_token.class', 'Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken')
                   ->shouldBeCalled();
         $container->setParameter('gesdinet.jwtrefreshtoken.entity_manager.id', 'doctrine.orm.entity_manager')
                   ->shouldBeCalled();
@@ -66,7 +66,7 @@ class GesdinetJWTRefreshTokenExtensionSpec extends ObjectBehavior
         $container->setDefinition(Argument::cetera())
                   ->willReturn();
 
-        $configs = [];
+        $configs = array();
         $this->load($configs, $container);
     }
 
@@ -84,9 +84,9 @@ class GesdinetJWTRefreshTokenExtensionSpec extends ObjectBehavior
         $container->setAlias(Argument::cetera())
                   ->willReturn();
 
-        $configs = [['parameter_name_generator' => 'some.service.name']];
-        $this->shouldThrow(ServiceNotFoundException::class)
-             ->during('load', [$configs, $container]);
+        $configs = array(array('parameter_name_generator' => 'some.service.name'));
+        $this->shouldThrow('\Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException')
+             ->during('load', array($configs, $container));
     }
 
     public function it_should_configure_a_custom_name_generator(ContainerBuilder $container)
@@ -107,7 +107,7 @@ class GesdinetJWTRefreshTokenExtensionSpec extends ObjectBehavior
         $container->setAlias(Argument::cetera())
                   ->willReturn();
 
-        $configs = [['parameter_name_generator' => 'some.service.name']];
+        $configs = array(array('parameter_name_generator' => 'some.service.name'));
         $this->load($configs, $container);
     }
 }

--- a/spec/DependencyInjection/GesdinetJWTRefreshTokenExtensionSpec.php
+++ b/spec/DependencyInjection/GesdinetJWTRefreshTokenExtensionSpec.php
@@ -46,7 +46,7 @@ class GesdinetJWTRefreshTokenExtensionSpec extends ObjectBehavior
         $container->setAlias(Argument::cetera())
                   ->willReturn();
 
-        $configs = [];
+        $configs = array();
         $this->load($configs, $container);
     }
 

--- a/spec/DependencyInjection/GesdinetJWTRefreshTokenExtensionSpec.php
+++ b/spec/DependencyInjection/GesdinetJWTRefreshTokenExtensionSpec.php
@@ -9,14 +9,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class GesdinetJWTRefreshTokenExtensionSpec extends ObjectBehavior
 {
-    public function let(ContainerBuilder $container)
-    {
-        $container->fileExists(dirname(dirname(__DIR__)).'/DependencyInjection/../Resources/config/services.yml')
-                  ->willReturn(true);
-        $container->has('gesdinet.jwtrefreshtoken.name_generator.underscore')
-                  ->willReturn(true);
-    }
-
     public function it_is_initializable()
     {
         $this->shouldHaveType('Gesdinet\JWTRefreshTokenBundle\DependencyInjection\GesdinetJWTRefreshTokenExtension');
@@ -24,6 +16,11 @@ class GesdinetJWTRefreshTokenExtensionSpec extends ObjectBehavior
 
     public function it_should_set_parameters_correctly(ContainerBuilder $container)
     {
+        $container->fileExists(dirname(dirname(__DIR__)).'/DependencyInjection/../Resources/config/services.yml')
+                  ->willReturn(true);
+        $container->has('gesdinet.jwtrefreshtoken.name_generator.underscore')
+                  ->willReturn(true);
+
         // setParameter calls with default values
         $container->setParameter('gesdinet_jwt_refresh_token.ttl', 2592000)
                   ->shouldBeCalled();
@@ -52,6 +49,11 @@ class GesdinetJWTRefreshTokenExtensionSpec extends ObjectBehavior
 
     public function it_should_configure_the_default_naming_generator(ContainerBuilder $container)
     {
+        $container->fileExists(dirname(dirname(__DIR__)).'/DependencyInjection/../Resources/config/services.yml')
+                  ->willReturn(true);
+        $container->has('gesdinet.jwtrefreshtoken.name_generator.underscore')
+                  ->willReturn(true);
+
         $container->setAlias(
             'gesdinet.jwtrefreshtoken.name_generator.default',
             Argument::exact(new Alias('gesdinet.jwtrefreshtoken.name_generator.underscore'))
@@ -71,6 +73,9 @@ class GesdinetJWTRefreshTokenExtensionSpec extends ObjectBehavior
     public function it_should_throw_an_exception_if_specifying_a_non_existent_name_generator_service(
         ContainerBuilder $container
     ) {
+        $container->fileExists(dirname(dirname(__DIR__)).'/DependencyInjection/../Resources/config/services.yml')
+                  ->willReturn(true);
+
         $container->has('some.service.name')
                   ->willReturn(false);
 
@@ -89,6 +94,12 @@ class GesdinetJWTRefreshTokenExtensionSpec extends ObjectBehavior
 
     public function it_should_configure_a_custom_name_generator(ContainerBuilder $container)
     {
+        $container->fileExists(dirname(dirname(__DIR__)).'/DependencyInjection/../Resources/config/services.yml')
+                  ->willReturn(true);
+        
+        $container->has('gesdinet.jwtrefreshtoken.name_generator.underscore')
+                  ->willReturn(true);
+
         // Expectations
         $container->setAlias('gesdinet.jwtrefreshtoken.name_generator.default', 'some.service.name')
                   ->shouldBeCalled();

--- a/spec/DependencyInjection/GesdinetJWTRefreshTokenExtensionSpec.php
+++ b/spec/DependencyInjection/GesdinetJWTRefreshTokenExtensionSpec.php
@@ -96,7 +96,7 @@ class GesdinetJWTRefreshTokenExtensionSpec extends ObjectBehavior
     {
         $container->fileExists(dirname(dirname(__DIR__)).'/DependencyInjection/../Resources/config/services.yml')
                   ->willReturn(true);
-        
+
         $container->has('gesdinet.jwtrefreshtoken.name_generator.underscore')
                   ->willReturn(true);
 

--- a/spec/EventListener/AttachRefreshTokenOnSuccessListenerSpec.php
+++ b/spec/EventListener/AttachRefreshTokenOnSuccessListenerSpec.php
@@ -76,7 +76,6 @@ class AttachRefreshTokenOnSuccessListenerSpec extends ObjectBehavior
         $this->attachRefreshToken($event);
     }
 
-
     public function it_is_not_valid_user(AuthenticationSuccessEvent $event)
     {
         $event->getData()->willReturn(array());
@@ -84,7 +83,6 @@ class AttachRefreshTokenOnSuccessListenerSpec extends ObjectBehavior
 
         $this->attachRefreshToken($event);
     }
-
 
     public function it_should_support_name_generator_for_data_array_key(AuthenticationSuccessEvent $event, UserInterface $user, RequestStack $requestStack, RequestRefreshToken $requestRefreshToken, NameGeneratorInterface $nameGenerator)
     {

--- a/spec/EventListener/AttachRefreshTokenOnSuccessListenerSpec.php
+++ b/spec/EventListener/AttachRefreshTokenOnSuccessListenerSpec.php
@@ -4,23 +4,25 @@ namespace spec\Gesdinet\JWTRefreshTokenBundle\EventListener;
 
 use Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken;
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManagerInterface;
+use Gesdinet\JWTRefreshTokenBundle\NameGenerator\NameGeneratorInterface;
+use Gesdinet\JWTRefreshTokenBundle\Request\RequestRefreshToken;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\AuthenticationSuccessEvent;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Symfony\Component\HttpFoundation\HeaderBag;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\HeaderBag;
-use Symfony\Component\HttpFoundation\ParameterBag;
 
 class AttachRefreshTokenOnSuccessListenerSpec extends ObjectBehavior
 {
-    public function let(RefreshTokenManagerInterface $refreshTokenManager, ValidatorInterface $validator, RequestStack $requestStack)
+    public function let(RefreshTokenManagerInterface $refreshTokenManager, ValidatorInterface $validator, RequestStack $requestStack, RequestRefreshToken $requestRefreshToken, NameGeneratorInterface $nameGenerator)
     {
         $ttl = 2592000;
-        $this->beConstructedWith($refreshTokenManager, $ttl, $validator, $requestStack);
+        $this->beConstructedWith($refreshTokenManager, $ttl, $validator, $requestStack, $requestRefreshToken, $nameGenerator);
     }
 
     public function it_is_initializable()
@@ -28,10 +30,12 @@ class AttachRefreshTokenOnSuccessListenerSpec extends ObjectBehavior
         $this->shouldHaveType('Gesdinet\JWTRefreshTokenBundle\EventListener\AttachRefreshTokenOnSuccessListener');
     }
 
-    public function it_attach_token_on_refresh(AuthenticationSuccessEvent $event, UserInterface $user, RefreshToken $refreshToken, $refreshTokenManager, RequestStack $requestStack)
+    public function it_attach_token_on_refresh(AuthenticationSuccessEvent $event, UserInterface $user, RequestStack $requestStack, RequestRefreshToken $requestRefreshToken, NameGeneratorInterface $nameGenerator)
     {
         $event->getData()->willReturn(array());
         $event->getUser()->willReturn($user);
+        $nameGenerator->generateName('refresh_token')
+                      ->willReturn('refresh_token');
 
         $refreshTokenArray = array('refresh_token' => 'thepreviouslyissuedrefreshtoken');
         $headers = new HeaderBag(array('content_type' => 'not-json'));
@@ -41,12 +45,14 @@ class AttachRefreshTokenOnSuccessListenerSpec extends ObjectBehavior
 
         $requestStack->getCurrentRequest()->willReturn($request);
 
+        $requestRefreshToken->getRefreshToken($request)->willReturn('thepreviouslyissuedrefreshtoken');
+
         $event->setData(Argument::exact($refreshTokenArray))->shouldBeCalled();
 
         $this->attachRefreshToken($event);
     }
 
-    public function it_attach_token_on_credentials_auth(HeaderBag $headers, ParameterBag $requestBag, AuthenticationSuccessEvent $event, UserInterface $user, RefreshToken $refreshToken, $refreshTokenManager, $validator, RequestStack $requestStack)
+    public function it_attach_token_on_credentials_auth(AuthenticationSuccessEvent $event, UserInterface $user, RefreshToken $refreshToken, $refreshTokenManager, $validator, RequestStack $requestStack)
     {
         $event->getData()->willReturn(array());
         $event->getUser()->willReturn($user);
@@ -70,10 +76,34 @@ class AttachRefreshTokenOnSuccessListenerSpec extends ObjectBehavior
         $this->attachRefreshToken($event);
     }
 
+
     public function it_is_not_valid_user(AuthenticationSuccessEvent $event)
     {
         $event->getData()->willReturn(array());
         $event->getUser()->willReturn(null);
+
+        $this->attachRefreshToken($event);
+    }
+
+
+    public function it_should_support_name_generator_for_data_array_key(AuthenticationSuccessEvent $event, UserInterface $user, RequestStack $requestStack, RequestRefreshToken $requestRefreshToken, NameGeneratorInterface $nameGenerator)
+    {
+        $event->getData()->willReturn(array());
+        $event->getUser()->willReturn($user);
+        $nameGenerator->generateName('refresh_token')
+                      ->willReturn('refreshToken');
+
+        $refreshTokenArray = array('refreshToken' => 'thepreviouslyissuedrefreshtoken');
+        $headers = new HeaderBag(array('content_type' => 'not-json'));
+        $request = new Request();
+        $request->headers = $headers;
+        $request->request = new ParameterBag($refreshTokenArray);
+
+        $requestStack->getCurrentRequest()->willReturn($request);
+
+        $requestRefreshToken->getRefreshToken($request)->willReturn('thepreviouslyissuedrefreshtoken');
+
+        $event->setData(Argument::exact($refreshTokenArray))->shouldBeCalled();
 
         $this->attachRefreshToken($event);
     }

--- a/spec/NameGenerator/CamelCaseNameGeneratorSpec.php
+++ b/spec/NameGenerator/CamelCaseNameGeneratorSpec.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace spec\Gesdinet\JWTRefreshTokenBundle\NameGenerator;
+
+use Gesdinet\JWTRefreshTokenBundle\NameGenerator\CamelCaseNameGenerator;
+use Gesdinet\JWTRefreshTokenBundle\NameGenerator\NameGeneratorInterface;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * Spec for Gesdinet\JWTRefreshTokenBundle\NameGenerator\CamelCaseNameGenerator
+ *
+ * @package Gesdinet\JWTRefreshTokenBundle\NameGenerator\CamelCaseNameGenerator
+ *
+ * @covers \Gesdinet\JWTRefreshTokenBundle\NameGenerator\CamelCaseNameGenerator
+ */
+class CamelCaseNameGeneratorSpec extends ObjectBehavior
+{
+    //------------------------------------------------------------------------------------------------------------------
+    // Spec: Class / interfaces
+    //------------------------------------------------------------------------------------------------------------------
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(CamelCaseNameGenerator::class);
+    }
+
+
+    /**
+     * @covers CamelCaseNameGenerator
+     */
+    function it_implements_name_generator_interface()
+    {
+        $this->shouldImplement(NameGeneratorInterface::class);
+    }
+
+
+    /**
+     * @covers CamelCaseNameGenerator::generateName()
+     */
+    function it_should_return_underscored_values_from_snake_case()
+    {
+        /** @var CamelCaseNameGenerator|CamelCaseNameGeneratorSpec $this */
+
+        // Method under test
+        $this->generateName('refresh_token')
+             ->shouldReturn('refreshToken');
+    }
+
+
+    /**
+     * @covers CamelCaseNameGenerator::generateName()
+     */
+    function it_should_return_underscored_values_from_camel_case()
+    {
+        /** @var CamelCaseNameGenerator|CamelCaseNameGeneratorSpec $this */
+
+        // Method under test
+        $this->generateName('refreshToken')
+             ->shouldReturn('refreshToken');
+    }
+}

--- a/spec/NameGenerator/CamelCaseNameGeneratorSpec.php
+++ b/spec/NameGenerator/CamelCaseNameGeneratorSpec.php
@@ -3,7 +3,6 @@
 namespace spec\Gesdinet\JWTRefreshTokenBundle\NameGenerator;
 
 use Gesdinet\JWTRefreshTokenBundle\NameGenerator\CamelCaseNameGenerator;
-use Gesdinet\JWTRefreshTokenBundle\NameGenerator\NameGeneratorInterface;
 use PhpSpec\ObjectBehavior;
 
 /**

--- a/spec/NameGenerator/CamelCaseNameGeneratorSpec.php
+++ b/spec/NameGenerator/CamelCaseNameGeneratorSpec.php
@@ -7,9 +7,7 @@ use Gesdinet\JWTRefreshTokenBundle\NameGenerator\NameGeneratorInterface;
 use PhpSpec\ObjectBehavior;
 
 /**
- * Spec for Gesdinet\JWTRefreshTokenBundle\NameGenerator\CamelCaseNameGenerator
- *
- * @package Gesdinet\JWTRefreshTokenBundle\NameGenerator\CamelCaseNameGenerator
+ * Spec for Gesdinet\JWTRefreshTokenBundle\NameGenerator\CamelCaseNameGenerator.
  *
  * @covers \Gesdinet\JWTRefreshTokenBundle\NameGenerator\CamelCaseNameGenerator
  */
@@ -19,40 +17,28 @@ class CamelCaseNameGeneratorSpec extends ObjectBehavior
     // Spec: Class / interfaces
     //------------------------------------------------------------------------------------------------------------------
 
-    function it_is_initializable()
+    public function it_is_initializable()
     {
         $this->shouldHaveType(CamelCaseNameGenerator::class);
     }
 
-
-    /**
-     * @covers CamelCaseNameGenerator
-     */
-    function it_implements_name_generator_interface()
+    public function it_implements_name_generator_interface()
     {
         $this->shouldImplement(NameGeneratorInterface::class);
     }
 
-
-    /**
-     * @covers CamelCaseNameGenerator::generateName()
-     */
-    function it_should_return_underscored_values_from_snake_case()
+    public function it_should_return_underscored_values_from_snake_case()
     {
-        /** @var CamelCaseNameGenerator|CamelCaseNameGeneratorSpec $this */
+        /* @var CamelCaseNameGenerator|CamelCaseNameGeneratorSpec $this */
 
         // Method under test
         $this->generateName('refresh_token')
              ->shouldReturn('refreshToken');
     }
 
-
-    /**
-     * @covers CamelCaseNameGenerator::generateName()
-     */
-    function it_should_return_underscored_values_from_camel_case()
+    public function it_should_return_underscored_values_from_camel_case()
     {
-        /** @var CamelCaseNameGenerator|CamelCaseNameGeneratorSpec $this */
+        /* @var CamelCaseNameGenerator|CamelCaseNameGeneratorSpec $this */
 
         // Method under test
         $this->generateName('refreshToken')

--- a/spec/NameGenerator/CamelCaseNameGeneratorSpec.php
+++ b/spec/NameGenerator/CamelCaseNameGeneratorSpec.php
@@ -19,12 +19,12 @@ class CamelCaseNameGeneratorSpec extends ObjectBehavior
 
     public function it_is_initializable()
     {
-        $this->shouldHaveType(CamelCaseNameGenerator::class);
+        $this->shouldHaveType('Gesdinet\JWTRefreshTokenBundle\NameGenerator\CamelCaseNameGenerator');
     }
 
     public function it_implements_name_generator_interface()
     {
-        $this->shouldImplement(NameGeneratorInterface::class);
+        $this->shouldImplement('Gesdinet\JWTRefreshTokenBundle\NameGenerator\NameGeneratorInterface');
     }
 
     public function it_should_return_underscored_values_from_snake_case()

--- a/spec/NameGenerator/UnderscoreNameGeneratorSpec.php
+++ b/spec/NameGenerator/UnderscoreNameGeneratorSpec.php
@@ -22,12 +22,10 @@ class UnderscoreNameGeneratorSpec extends ObjectBehavior
         $this->shouldHaveType(UnderscoreNameGenerator::class);
     }
 
-
     public function it_implements_name_generator_interface()
     {
         $this->shouldImplement(NameGeneratorInterface::class);
     }
-
 
     public function it_should_return_underscored_values_from_snake_case()
     {

--- a/spec/NameGenerator/UnderscoreNameGeneratorSpec.php
+++ b/spec/NameGenerator/UnderscoreNameGeneratorSpec.php
@@ -7,9 +7,7 @@ use Gesdinet\JWTRefreshTokenBundle\NameGenerator\UnderscoreNameGenerator;
 use PhpSpec\ObjectBehavior;
 
 /**
- * Spec for Gesdinet\JWTRefreshTokenBundle\NameGenerator\UnderscoreNameGenerator
- *
- * @package Gesdinet\JWTRefreshTokenBundle\NameGenerator\UnderscoreNameGenerator
+ * Spec for Gesdinet\JWTRefreshTokenBundle\NameGenerator\UnderscoreNameGenerator.
  *
  * @covers  \Gesdinet\JWTRefreshTokenBundle\NameGenerator\UnderscoreNameGenerator
  */
@@ -19,40 +17,30 @@ class UnderscoreNameGeneratorSpec extends ObjectBehavior
     // Spec: Class / interfaces
     //------------------------------------------------------------------------------------------------------------------
 
-    function it_is_initializable()
+    public function it_is_initializable()
     {
         $this->shouldHaveType(UnderscoreNameGenerator::class);
     }
 
 
-    /**
-     * @covers UnderscoreNameGenerator
-     */
-    function it_implements_name_generator_interface()
+    public function it_implements_name_generator_interface()
     {
         $this->shouldImplement(NameGeneratorInterface::class);
     }
 
 
-    /**
-     * @covers UnderscoreNameGenerator::generateName()
-     */
-    function it_should_return_underscored_values_from_snake_case()
+    public function it_should_return_underscored_values_from_snake_case()
     {
-        /** @var UnderscoreNameGenerator|UnderscoreNameGeneratorSpec $this */
+        /* @var UnderscoreNameGenerator|UnderscoreNameGeneratorSpec $this */
 
         // Method under test
         $this->generateName('refresh_token')
             ->shouldReturn('refresh_token');
     }
 
-
-    /**
-     * @covers UnderscoreNameGenerator::generateName()
-     */
-    function it_should_return_underscored_values_from_camel_case()
+    public function it_should_return_underscored_values_from_camel_case()
     {
-        /** @var UnderscoreNameGenerator|UnderscoreNameGeneratorSpec $this */
+        /* @var UnderscoreNameGenerator|UnderscoreNameGeneratorSpec $this */
 
         // Method under test
         $this->generateName('refreshToken')

--- a/spec/NameGenerator/UnderscoreNameGeneratorSpec.php
+++ b/spec/NameGenerator/UnderscoreNameGeneratorSpec.php
@@ -2,7 +2,6 @@
 
 namespace spec\Gesdinet\JWTRefreshTokenBundle\NameGenerator;
 
-use Gesdinet\JWTRefreshTokenBundle\NameGenerator\NameGeneratorInterface;
 use Gesdinet\JWTRefreshTokenBundle\NameGenerator\UnderscoreNameGenerator;
 use PhpSpec\ObjectBehavior;
 

--- a/spec/NameGenerator/UnderscoreNameGeneratorSpec.php
+++ b/spec/NameGenerator/UnderscoreNameGeneratorSpec.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace spec\Gesdinet\JWTRefreshTokenBundle\NameGenerator;
+
+use Gesdinet\JWTRefreshTokenBundle\NameGenerator\NameGeneratorInterface;
+use Gesdinet\JWTRefreshTokenBundle\NameGenerator\UnderscoreNameGenerator;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * Spec for Gesdinet\JWTRefreshTokenBundle\NameGenerator\UnderscoreNameGenerator
+ *
+ * @package Gesdinet\JWTRefreshTokenBundle\NameGenerator\UnderscoreNameGenerator
+ *
+ * @covers  \Gesdinet\JWTRefreshTokenBundle\NameGenerator\UnderscoreNameGenerator
+ */
+class UnderscoreNameGeneratorSpec extends ObjectBehavior
+{
+    //------------------------------------------------------------------------------------------------------------------
+    // Spec: Class / interfaces
+    //------------------------------------------------------------------------------------------------------------------
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(UnderscoreNameGenerator::class);
+    }
+
+
+    /**
+     * @covers UnderscoreNameGenerator
+     */
+    function it_implements_name_generator_interface()
+    {
+        $this->shouldImplement(NameGeneratorInterface::class);
+    }
+
+
+    /**
+     * @covers UnderscoreNameGenerator::generateName()
+     */
+    function it_should_return_underscored_values_from_snake_case()
+    {
+        /** @var UnderscoreNameGenerator|UnderscoreNameGeneratorSpec $this */
+
+        // Method under test
+        $this->generateName('refresh_token')
+            ->shouldReturn('refresh_token');
+    }
+
+
+    /**
+     * @covers UnderscoreNameGenerator::generateName()
+     */
+    function it_should_return_underscored_values_from_camel_case()
+    {
+        /** @var UnderscoreNameGenerator|UnderscoreNameGeneratorSpec $this */
+
+        // Method under test
+        $this->generateName('refreshToken')
+             ->shouldReturn('refresh_token');
+    }
+}

--- a/spec/NameGenerator/UnderscoreNameGeneratorSpec.php
+++ b/spec/NameGenerator/UnderscoreNameGeneratorSpec.php
@@ -19,12 +19,12 @@ class UnderscoreNameGeneratorSpec extends ObjectBehavior
 
     public function it_is_initializable()
     {
-        $this->shouldHaveType(UnderscoreNameGenerator::class);
+        $this->shouldHaveType('Gesdinet\JWTRefreshTokenBundle\NameGenerator\UnderscoreNameGenerator');
     }
 
     public function it_implements_name_generator_interface()
     {
-        $this->shouldImplement(NameGeneratorInterface::class);
+        $this->shouldImplement('Gesdinet\JWTRefreshTokenBundle\NameGenerator\NameGeneratorInterface');
     }
 
     public function it_should_return_underscored_values_from_snake_case()

--- a/spec/Request/RequestRefreshTokenSpec.php
+++ b/spec/Request/RequestRefreshTokenSpec.php
@@ -2,17 +2,27 @@
 
 namespace spec\Gesdinet\JWTRefreshTokenBundle\Request;
 
+use Gesdinet\JWTRefreshTokenBundle\NameGenerator\NameGeneratorInterface;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\HttpFoundation\Request;
 
 class RequestRefreshTokenSpec extends ObjectBehavior
 {
+    function let(NameGeneratorInterface $nameGenerator)
+    {
+        $this->beConstructedWith($nameGenerator);
+        
+        $nameGenerator->generateName('refresh_token')
+            ->willReturn('refresh_token');
+    }
+
+
     public function it_gets_from_query_param()
     {
         $request = Request::createFromGlobals();
         $request->attributes->set('refresh_token', 'abcd');
 
-        $this::getRefreshToken($request)->shouldBe('abcd');
+        $this->getRefreshToken($request)->shouldBe('abcd');
     }
 
     public function it_gets_from_body()
@@ -20,7 +30,7 @@ class RequestRefreshTokenSpec extends ObjectBehavior
         $request = Request::createFromGlobals();
         $request->request->set('refresh_token', 'abcd');
 
-        $this::getRefreshToken($request)->shouldBe('abcd');
+        $this->getRefreshToken($request)->shouldBe('abcd');
     }
 
     public function it_gets_from_json()
@@ -28,7 +38,7 @@ class RequestRefreshTokenSpec extends ObjectBehavior
         $request = Request::create(null, 'POST', array(), array(), array(), array(), json_encode(array('refresh_token' => 'abcd')));
         $request->headers->set('content_type', 'application/json');
 
-        $this::getRefreshToken($request)->shouldBe('abcd');
+        $this->getRefreshToken($request)->shouldBe('abcd');
     }
 
     public function it_gets_from_json_x()
@@ -36,7 +46,7 @@ class RequestRefreshTokenSpec extends ObjectBehavior
         $request = Request::create(null, 'POST', array(), array(), array(), array(), json_encode(array('refresh_token' => 'abcd')));
         $request->headers->set('content_type', 'application/x-json');
 
-        $this::getRefreshToken($request)->shouldBe('abcd');
+        $this->getRefreshToken($request)->shouldBe('abcd');
     }
 
     public function it_gets_from_json_parameter()
@@ -44,6 +54,62 @@ class RequestRefreshTokenSpec extends ObjectBehavior
         $request = Request::create(null, 'POST', array(), array(), array(), array(), json_encode(array('refresh_token' => 'abcd')));
         $request->headers->set('content_type', 'application/json;charset=UTF-8');
 
-        $this::getRefreshToken($request)->shouldBe('abcd');
+        $this->getRefreshToken($request)->shouldBe('abcd');
+    }
+
+
+    public function it_gets_from_query_param_using_camel_case_naming(NameGeneratorInterface $nameGenerator)
+    {
+        $nameGenerator->generateName('refresh_token')
+            ->willReturn('refreshToken');
+
+        $request = Request::createFromGlobals();
+        $request->attributes->set('refreshToken', 'abcd');
+
+        $this->getRefreshToken($request)->shouldBe('abcd');
+    }
+
+    public function it_gets_from_body_using_camel_case_naming(NameGeneratorInterface $nameGenerator)
+    {
+        $nameGenerator->generateName('refresh_token')
+            ->willReturn('refreshToken');
+
+        $request = Request::createFromGlobals();
+        $request->request->set('refreshToken', 'abcd');
+
+        $this->getRefreshToken($request)->shouldBe('abcd');
+    }
+
+    public function it_gets_from_json_using_camel_case_naming(NameGeneratorInterface $nameGenerator)
+    {
+        $nameGenerator->generateName('refresh_token')
+            ->willReturn('refreshToken');
+
+        $request = Request::create(null, 'POST', array(), array(), array(), array(), json_encode(array('refreshToken' => 'abcd')));
+        $request->headers->set('content_type', 'application/json');
+
+        $this->getRefreshToken($request)->shouldBe('abcd');
+    }
+
+    public function it_gets_from_json_x_using_camel_case_naming(NameGeneratorInterface $nameGenerator)
+    {
+        $nameGenerator->generateName('refresh_token')
+            ->willReturn('refreshToken');
+
+        $request = Request::create(null, 'POST', array(), array(), array(), array(), json_encode(array('refreshToken' => 'abcd')));
+        $request->headers->set('content_type', 'application/x-json');
+
+        $this->getRefreshToken($request)->shouldBe('abcd');
+    }
+
+    public function it_gets_from_json_parameter_using_camel_case_naming(NameGeneratorInterface $nameGenerator)
+    {
+        $nameGenerator->generateName('refresh_token')
+            ->willReturn('refreshToken');
+
+        $request = Request::create(null, 'POST', array(), array(), array(), array(), json_encode(array('refreshToken' => 'abcd')));
+        $request->headers->set('content_type', 'application/json;charset=UTF-8');
+
+        $this->getRefreshToken($request)->shouldBe('abcd');
     }
 }

--- a/spec/Request/RequestRefreshTokenSpec.php
+++ b/spec/Request/RequestRefreshTokenSpec.php
@@ -8,14 +8,13 @@ use Symfony\Component\HttpFoundation\Request;
 
 class RequestRefreshTokenSpec extends ObjectBehavior
 {
-    function let(NameGeneratorInterface $nameGenerator)
+    public function let(NameGeneratorInterface $nameGenerator)
     {
         $this->beConstructedWith($nameGenerator);
-        
+
         $nameGenerator->generateName('refresh_token')
             ->willReturn('refresh_token');
     }
-
 
     public function it_gets_from_query_param()
     {
@@ -56,7 +55,6 @@ class RequestRefreshTokenSpec extends ObjectBehavior
 
         $this->getRefreshToken($request)->shouldBe('abcd');
     }
-
 
     public function it_gets_from_query_param_using_camel_case_naming(NameGeneratorInterface $nameGenerator)
     {

--- a/spec/Security/Authenticator/RefreshTokenAuthenticatorSpec.php
+++ b/spec/Security/Authenticator/RefreshTokenAuthenticatorSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Gesdinet\JWTRefreshTokenBundle\Security\Authenticator;
 
+use Gesdinet\JWTRefreshTokenBundle\Request\RequestRefreshToken;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken;
@@ -9,6 +10,11 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 class RefreshTokenAuthenticatorSpec extends ObjectBehavior
 {
+    function let(RequestRefreshToken $requestRefreshToken)
+    {
+        $this->beConstructedWith($requestRefreshToken);
+    }
+
     public function it_is_initializable()
     {
         $this->shouldHaveType('Gesdinet\JWTRefreshTokenBundle\Security\Authenticator\RefreshTokenAuthenticator');
@@ -18,6 +24,22 @@ class RefreshTokenAuthenticatorSpec extends ObjectBehavior
     {
         $token->getProviderKey()->willReturn($providerKey);
         $this->supportsToken($token, $providerKey)->shouldBe(true);
+    }
+
+    function it_creates_token(RequestRefreshToken $requestRefreshToken, Request $request)
+    {
+        $providerKey = 'api';
+
+        // Stubs
+        $requestRefreshToken->getRefreshToken($request)
+            ->willReturn('arefreshtokenstring');
+
+        $this->createToken($request, $providerKey)
+            ->shouldBeLike(new PreAuthenticatedToken(
+                '',
+                'arefreshtokenstring',
+                $providerKey
+            ));
     }
 
     public function it_fails_on_authentication(Request $request, AuthenticationException $exception)

--- a/spec/Security/Authenticator/RefreshTokenAuthenticatorSpec.php
+++ b/spec/Security/Authenticator/RefreshTokenAuthenticatorSpec.php
@@ -10,7 +10,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 class RefreshTokenAuthenticatorSpec extends ObjectBehavior
 {
-    function let(RequestRefreshToken $requestRefreshToken)
+    public function let(RequestRefreshToken $requestRefreshToken)
     {
         $this->beConstructedWith($requestRefreshToken);
     }
@@ -26,7 +26,7 @@ class RefreshTokenAuthenticatorSpec extends ObjectBehavior
         $this->supportsToken($token, $providerKey)->shouldBe(true);
     }
 
-    function it_creates_token(RequestRefreshToken $requestRefreshToken, Request $request)
+    public function it_creates_token(RequestRefreshToken $requestRefreshToken, Request $request)
     {
         $providerKey = 'api';
 


### PR DESCRIPTION
I needed to rename `refresh_token` to `refreshToken` for my project, to match the rest of the API.

So I thought I'd submit a PR for this added functionality.

Let me know if this works OK for you, or if anything needs changing.