### PR TITLE
Compatibility with Symfony4.0 & 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 matrix:
   fast_finish: true
   include:
-    - php: 7.2
+    - php: 7.0
       env: SYMFONY_VERSION=3.4.*
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ matrix:
   fast_finish: true
   include:
     # 3.3.*
+    - php: 5.5
+      env: SYMFONY_VERSION=3.3.*
+    - php: 5.6
+      env: SYMFONY_VERSION=3.3.*
     - php: 7.0
       env: SYMFONY_VERSION=3.3.*
     - php: 7.1
@@ -11,6 +15,10 @@ matrix:
     - php: 7.2
       env: SYMFONY_VERSION=3.3.*
       # 3.4.*
+    - php: 5.5
+      env: SYMFONY_VERSION=3.3.*
+    - php: 5.6
+      env: SYMFONY_VERSION=3.3.*
     - php: 7.0
       env: SYMFONY_VERSION=3.4.*
     - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,14 @@ matrix:
   include:
     - php: 7.0
       env: SYMFONY_VERSION=3.4.*
+    - php: 7.1
+      env: SYMFONY_VERSION=3.4.*
+    - php: 7.2
+      env: SYMFONY_VERSION=3.4.*
+    - php: 7.1
+      env: SYMFONY_VERSION=4.0.*
+    - php: 7.2
+      env: SYMFONY_VERSION=4.0.*
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,21 @@ language: php
 matrix:
   fast_finish: true
   include:
+    # 3.3.*
+    - php: 7.0
+      env: SYMFONY_VERSION=3.3.*
+    - php: 7.1
+      env: SYMFONY_VERSION=3.3.*
+    - php: 7.2
+      env: SYMFONY_VERSION=3.3.*
+      # 3.4.*
     - php: 7.0
       env: SYMFONY_VERSION=3.4.*
     - php: 7.1
       env: SYMFONY_VERSION=3.4.*
     - php: 7.2
       env: SYMFONY_VERSION=3.4.*
+      # 4.0.*
     - php: 7.1
       env: SYMFONY_VERSION=4.0.*
     - php: 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ matrix:
   fast_finish: true
   include:
     # 3.3.*
-    - php: 5.5
-      env: SYMFONY_VERSION=3.3.*
-    - php: 5.6
-      env: SYMFONY_VERSION=3.3.*
     - php: 7.0
       env: SYMFONY_VERSION=3.3.*
     - php: 7.1
@@ -15,10 +11,6 @@ matrix:
     - php: 7.2
       env: SYMFONY_VERSION=3.3.*
       # 3.4.*
-    - php: 5.5
-      env: SYMFONY_VERSION=3.3.*
-    - php: 5.6
-      env: SYMFONY_VERSION=3.3.*
     - php: 7.0
       env: SYMFONY_VERSION=3.4.*
     - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,36 +3,8 @@ language: php
 matrix:
   fast_finish: true
   include:
-    - php: 5.3
-      env: SYMFONY_VERSION=2.5.*
-    - php: 5.4
-      env: SYMFONY_VERSION=2.5.*
-    - php: 5.5
-      env: SYMFONY_VERSION=2.5.*
-    - php: 5.6
-      env: SYMFONY_VERSION=2.5.*
-    - php: 5.3
-      env: SYMFONY_VERSION=2.7.*
-    - php: 5.4
-      env: SYMFONY_VERSION=2.7.*
-    - php: 5.5
-      env: SYMFONY_VERSION=2.7.*
-    - php: 5.6
-      env: SYMFONY_VERSION=2.7.*
-    - php: 7.0
-      env: SYMFONY_VERSION=2.7.*
-    - php: 5.5
-      env: SYMFONY_VERSION=2.8.*
-    - php: 5.6
-      env: SYMFONY_VERSION=2.8.*
-    - php: 7.0
-      env: SYMFONY_VERSION=2.8.*
-    - php: 5.5
-      env: SYMFONY_VERSION=3.0.*
-    - php: 5.6
-      env: SYMFONY_VERSION=3.0.*
-    - php: 7.0
-      env: SYMFONY_VERSION=3.0.*
+    - php: 7.2
+      env: SYMFONY_VERSION=3.4.*
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The purpose of this bundle is manage refresh tokens with JWT (Json Web Tokens) i
 Prerequisites
 -------------
 
-This bundle requires Symfony 2.5+ and supports Symfony 3 too.
+This bundle requires Symfony 3.3+ or 4.0+.
 
 **Protip:** Though the bundle doesn't enforce you to do so, it is highly recommended to use HTTPS.
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -22,3 +22,7 @@ services:
 
     gesdinet.jwtrefreshtoken.authenticator:
         class: Gesdinet\JWTRefreshTokenBundle\Security\Authenticator\RefreshTokenAuthenticator
+
+    Gesdinet\JWTRefreshTokenBundle\Command\:
+        resource: '../../Command/*'
+        tags: ['console.command']

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,12 @@
   ],
   "require" : {
     "php": ">=5.3.3",
-    "symfony/framework-bundle": "~2.3|~3.0|~4.0",
-    "symfony/validator": "~2.3|~3.0|~4.0",
+    "symfony/framework-bundle": "~3.3|~4.0",
+    "symfony/validator": "~3.3|~4.0",
     "doctrine/orm": "^2.4.8",
     "doctrine/doctrine-bundle": "~1.4",
-    "lexik/jwt-authentication-bundle": "^1.1|^2.0@dev"
+    "lexik/jwt-authentication-bundle": "^1.1|^2.0@dev",
+    "symfony/symfony": "3.3.*"
   },
   "require-dev": {
     "phpspec/phpspec": "^4.0"

--- a/composer.json
+++ b/composer.json
@@ -14,15 +14,14 @@
   ],
   "require" : {
     "php": ">=5.3.3",
-    "symfony/framework-bundle": "~2.3|~3.0",
-    "symfony/validator": "~2.3|~3.0",
+    "symfony/framework-bundle": "~2.3|~3.0|~4.0",
+    "symfony/validator": "~2.3|~3.0|~4.0",
     "doctrine/orm": "^2.4.8",
     "doctrine/doctrine-bundle": "~1.4",
     "lexik/jwt-authentication-bundle": "^1.1|^2.0@dev"
   },
   "require-dev": {
-    "phpspec/phpspec": "~2.0",
-    "henrikbjorn/phpspec-code-coverage": "~1.0"
+    "phpspec/phpspec": "^4.0"
   },
   "config": {
     "bin-dir": "bin"

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
     "symfony/validator": "~3.3|~4.0",
     "doctrine/orm": "^2.4.8",
     "doctrine/doctrine-bundle": "~1.4",
-    "lexik/jwt-authentication-bundle": "^1.1|^2.0@dev",
-    "symfony/symfony": "3.3.*"
+    "lexik/jwt-authentication-bundle": "^1.1|^2.0@dev"
   },
   "require-dev": {
     "phpspec/phpspec": "^4.0"

--- a/phpspec.yml
+++ b/phpspec.yml
@@ -4,9 +4,6 @@ suites:
         psr4_prefix: Gesdinet\JWTRefreshTokenBundle
         src_path: .
 
-extensions:
-    - PhpSpec\Extension\CodeCoverageExtension
-
 code_coverage:
   whitelist:
     - Command

--- a/spec/DependencyInjection/GesdinetJWTRefreshTokenExtensionSpec.php
+++ b/spec/DependencyInjection/GesdinetJWTRefreshTokenExtensionSpec.php
@@ -3,7 +3,9 @@
 namespace spec\Gesdinet\JWTRefreshTokenBundle\DependencyInjection;
 
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 class GesdinetJWTRefreshTokenExtensionSpec extends ObjectBehavior
 {
@@ -12,8 +14,24 @@ class GesdinetJWTRefreshTokenExtensionSpec extends ObjectBehavior
         $this->shouldHaveType('Gesdinet\JWTRefreshTokenBundle\DependencyInjection\GesdinetJWTRefreshTokenExtension');
     }
 
-    public function it_should_set_parameters_correctly(ContainerBuilder $container)
+    public function it_should_set_parameters_correctly(ContainerBuilder $container, ParameterBag $parameterBag)
     {
+        $parameterBag->resolveValue(Argument::type('string'))->will(function ($args) {
+            return $args[0];
+        });
+        $parameterBag->unescapeValue(Argument::type('string'))->will(function ($args) {
+            return $args[0];
+        });
+
+        $container->getParameterBag()->willReturn($parameterBag);
+        $container->fileExists(Argument::any())->willReturn(true);
+        $container->setParameter(Argument::any(), Argument::any())->will(function() {});
+        $container->setDefinition(Argument::any(), Argument::any())->will(function() {});
+        $container->getReflectionClass(Argument::type('string'))->will(function ($args) {
+            return new \ReflectionClass($args[0]);
+        });
+        $container->addResource(Argument::any())->willReturn(null);
+
         $configs = array();
         $this->load($configs, $container);
     }


### PR DESCRIPTION
In this PR there are several breakings changes but I'm not sure we can do otherwise.

The first is because of PHPSpec.
PHPSpec 2 is not compatible with SF4, I replaced it with PHPSpec4 and it is not compatible with "henrikbjorn/phpspec-code-coverage" so I removed it.

Update for SF4 is only supported by 3.3 and 3.4. Initial support of 2.5, 2.7, 3.0 in travis is impossible.