### PR TITLE
Fix command for SF4

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -10,6 +10,7 @@ services:
 
     gesdinet.jwtrefreshtoken.refresh_token_manager:
         class: Gesdinet\JWTRefreshTokenBundle\Doctrine\RefreshTokenManager
+        public: true
         arguments: [ "@gesdinet.jwtrefreshtoken.entity_manager", "%gesdinet.jwtrefreshtoken.refresh_token.class%" ]
 
     gesdinet.jwtrefreshtoken:


### PR DESCRIPTION
Because of missing "public: true" to "refresh_token_manager", commands does not works with sf4.

This PR fix it.