### PR TITLE
Refresh token override

### DIFF
--- a/DependencyInjection/Compiler/DoctrineMappingsCompilerPass.php
+++ b/DependencyInjection/Compiler/DoctrineMappingsCompilerPass.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Gesdinet\JWTRefreshTokenBundle\DependencyInjection\Compiler;
+
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class DoctrineMappingsCompilerPass
+ *
+ * We can't add DoctrineOrmMappingsPass directly, because in GesdinetJWTRefreshTokenBundle->build we don't have current
+ * bundle configuration yet.
+ * This CompilerPass is effectively just a wrapper for DoctrineOrmMappingsPass, which passes mappings conditionally.
+ *
+ * @package Gesdinet\JWTRefreshTokenBundle\DependencyInjection\Compiler
+ */
+final class DoctrineMappingsCompilerPass implements CompilerPassInterface
+{
+    /**
+     * Process Doctrine mappings based on gesdinet_jwt_refresh_token.refresh_token_entity config parameter.
+     * If this parameter contains user-defined entity, RefreshToken will be registered as a mapped superclass, not as an
+     * entity, to prevent Doctrine creating table for it and avoid conflicts with user-defined entity.
+     *
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $mappings = [
+            realpath(__DIR__.'/../../Resources/config/doctrine-orm') => 'Gesdinet\JWTRefreshTokenBundle\Entity',
+        ];
+        $config = $container->getExtensionConfig('gesdinet_jwt_refresh_token')[0];
+        if (isset($config['refresh_token_entity'])) {
+            $mappings[realpath(__DIR__.'/../../Resources/config/doctrine-superclass')] = 'Gesdinet\JWTRefreshTokenBundle\Entity';
+        } else {
+            $mappings[realpath(__DIR__.'/../../Resources/config/doctrine-entity')] = 'Gesdinet\JWTRefreshTokenBundle\Entity';
+        }
+
+        $pass = DoctrineOrmMappingsPass::createYamlMappingDriver($mappings);
+        $pass->process($container);
+    }
+
+}

--- a/DependencyInjection/Compiler/DoctrineMappingsCompilerPass.php
+++ b/DependencyInjection/Compiler/DoctrineMappingsCompilerPass.php
@@ -26,9 +26,9 @@ final class DoctrineMappingsCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $mappings = [
+        $mappings = array(
             realpath(__DIR__.'/../../Resources/config/doctrine-orm') => 'Gesdinet\JWTRefreshTokenBundle\Entity',
-        ];
+        );
         $config = $container->getExtensionConfig('gesdinet_jwt_refresh_token')[0];
         if (isset($config['refresh_token_entity'])) {
             $mappings[realpath(__DIR__.'/../../Resources/config/doctrine-superclass')] = 'Gesdinet\JWTRefreshTokenBundle\Entity';

--- a/Doctrine/RefreshTokenManager.php
+++ b/Doctrine/RefreshTokenManager.php
@@ -12,15 +12,25 @@
 namespace Gesdinet\JWTRefreshTokenBundle\Doctrine;
 
 use Doctrine\Common\Persistence\ObjectManager;
+use Gesdinet\JWTRefreshTokenBundle\Entity\RefreshTokenRepository;
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManager as BaseRefreshTokenManager;
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
 
 class RefreshTokenManager extends BaseRefreshTokenManager
 {
+    /**
+     * @var ObjectManager
+     */
     protected $objectManager;
 
+    /**
+     * @var string
+     */
     protected $class;
 
+    /**
+     * @var RefreshTokenRepository
+     */
     protected $repository;
 
     /**

--- a/Entity/AbstractRefreshToken.php
+++ b/Entity/AbstractRefreshToken.php
@@ -11,7 +11,6 @@
 
 namespace Gesdinet\JWTRefreshTokenBundle\Entity;
 
-use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
@@ -19,7 +18,6 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 /**
  * Abstract Refresh Token.
  *
- * @ORM\MappedSuperclass()
  * @UniqueEntity("refreshToken")
  */
 abstract class AbstractRefreshToken implements RefreshTokenInterface
@@ -27,7 +25,6 @@ abstract class AbstractRefreshToken implements RefreshTokenInterface
     /**
      * @var string
      *
-     * @ORM\Column(name="refresh_token", type="string", length=128, unique=true)
      * @Assert\NotBlank()
      */
     private $refreshToken;
@@ -35,15 +32,13 @@ abstract class AbstractRefreshToken implements RefreshTokenInterface
     /**
      * @var string
      *
-     * @ORM\Column(name="username", type="string", length=255)
      * @Assert\NotBlank()
      */
     private $username;
 
     /**
-     * @var string
+     * @var \DateTime
      *
-     * @ORM\Column(name="valid", type="datetime")
      * @Assert\NotBlank()
      */
     private $valid;
@@ -58,7 +53,7 @@ abstract class AbstractRefreshToken implements RefreshTokenInterface
      *
      * @param string $refreshToken
      *
-     * @return RefreshToken
+     * @return AbstractRefreshToken
      */
     public function setRefreshToken($refreshToken = null)
     {
@@ -86,7 +81,7 @@ abstract class AbstractRefreshToken implements RefreshTokenInterface
      *
      * @param \DateTime $valid
      *
-     * @return RefreshToken
+     * @return AbstractRefreshToken
      */
     public function setValid($valid)
     {
@@ -110,7 +105,7 @@ abstract class AbstractRefreshToken implements RefreshTokenInterface
      *
      * @param string $username
      *
-     * @return RefreshToken
+     * @return AbstractRefreshToken
      */
     public function setUsername($username)
     {

--- a/Entity/AbstractRefreshToken.php
+++ b/Entity/AbstractRefreshToken.php
@@ -1,0 +1,152 @@
+<?php
+
+/*
+ * This file is part of the GesdinetJWTRefreshTokenBundle package.
+ *
+ * (c) Gesdinet <http://www.gesdinet.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gesdinet\JWTRefreshTokenBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
+use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+
+/**
+ * Abstract Refresh Token.
+ *
+ * @ORM\MappedSuperclass()
+ * @UniqueEntity("refreshToken")
+ */
+abstract class AbstractRefreshToken implements RefreshTokenInterface
+{
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="refresh_token", type="string", length=128, unique=true)
+     * @Assert\NotBlank()
+     */
+    private $refreshToken;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="username", type="string", length=255)
+     * @Assert\NotBlank()
+     */
+    private $username;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="valid", type="datetime")
+     * @Assert\NotBlank()
+     */
+    private $valid;
+
+    /**
+     * {@inheritdoc}
+     */
+    abstract public function getId();
+
+    /**
+     * Set refreshToken.
+     *
+     * @param string $refreshToken
+     *
+     * @return RefreshToken
+     */
+    public function setRefreshToken($refreshToken = null)
+    {
+        if (null == $refreshToken) {
+            $this->refreshToken = bin2hex(openssl_random_pseudo_bytes(64));
+        } else {
+            $this->refreshToken = $refreshToken;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get refreshToken.
+     *
+     * @return string
+     */
+    public function getRefreshToken()
+    {
+        return $this->refreshToken;
+    }
+
+    /**
+     * Set valid.
+     *
+     * @param \DateTime $valid
+     *
+     * @return RefreshToken
+     */
+    public function setValid($valid)
+    {
+        $this->valid = $valid;
+
+        return $this;
+    }
+
+    /**
+     * Get valid.
+     *
+     * @return \DateTime
+     */
+    public function getValid()
+    {
+        return $this->valid;
+    }
+
+    /**
+     * Set username.
+     *
+     * @param string $username
+     *
+     * @return RefreshToken
+     */
+    public function setUsername($username)
+    {
+        $this->username = $username;
+
+        return $this;
+    }
+
+    /**
+     * Get username.
+     *
+     * @return string
+     */
+    public function getUsername()
+    {
+        return $this->username;
+    }
+
+    /**
+     * Check if is a valid refresh token.
+     *
+     * @return bool
+     */
+    public function isValid()
+    {
+        $datetime = new \DateTime();
+
+        return ($this->valid >= $datetime) ? true : false;
+    }
+
+    /**
+     * @return string Refresh Token
+     */
+    public function __toString()
+    {
+        return $this->getRefreshToken();
+    }
+}

--- a/Entity/AbstractRefreshToken.php
+++ b/Entity/AbstractRefreshToken.php
@@ -57,7 +57,7 @@ abstract class AbstractRefreshToken implements RefreshTokenInterface
      */
     public function setRefreshToken($refreshToken = null)
     {
-        if (null == $refreshToken) {
+        if (null === $refreshToken) {
             $this->refreshToken = bin2hex(openssl_random_pseudo_bytes(64));
         } else {
             $this->refreshToken = $refreshToken;
@@ -133,7 +133,7 @@ abstract class AbstractRefreshToken implements RefreshTokenInterface
     {
         $datetime = new \DateTime();
 
-        return ($this->valid >= $datetime) ? true : false;
+        return $this->valid >= $datetime;
     }
 
     /**

--- a/Entity/AbstractRefreshToken.php
+++ b/Entity/AbstractRefreshToken.php
@@ -24,7 +24,6 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
  */
 abstract class AbstractRefreshToken implements RefreshTokenInterface
 {
-
     /**
      * @var string
      *

--- a/Entity/RefreshToken.php
+++ b/Entity/RefreshToken.php
@@ -11,24 +11,17 @@
 
 namespace Gesdinet\JWTRefreshTokenBundle\Entity;
 
-use Doctrine\ORM\Mapping as ORM;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 /**
  * Refresh Token.
  *
- * @ORM\Table("refresh_tokens")
- * @ORM\Entity(repositoryClass="Gesdinet\JWTRefreshTokenBundle\Entity\RefreshTokenRepository")
  * @UniqueEntity("refreshToken")
  */
 class RefreshToken extends AbstractRefreshToken
 {
     /**
      * @var int
-     *
-     * @ORM\Column(name="id", type="integer")
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
      */
     protected $id;
 

--- a/Entity/RefreshToken.php
+++ b/Entity/RefreshToken.php
@@ -23,7 +23,7 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
  * @ORM\Entity(repositoryClass="Gesdinet\JWTRefreshTokenBundle\Entity\RefreshTokenRepository")
  * @UniqueEntity("refreshToken")
  */
-class RefreshToken implements RefreshTokenInterface
+class RefreshToken extends AbstractRefreshToken
 {
     /**
      * @var int
@@ -35,132 +35,10 @@ class RefreshToken implements RefreshTokenInterface
     protected $id;
 
     /**
-     * @var string
-     *
-     * @ORM\Column(name="refresh_token", type="string", length=128, unique=true)
-     * @Assert\NotBlank()
-     */
-    protected $refreshToken;
-
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="username", type="string", length=255)
-     * @Assert\NotBlank()
-     */
-    protected $username;
-
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="valid", type="datetime")
-     * @Assert\NotBlank()
-     */
-    protected $valid;
-
-    /**
-     * Get id.
-     *
-     * @return int
+     * {@inheritdoc}
      */
     public function getId()
     {
-        return $this->id;
-    }
-
-    /**
-     * Set refreshToken.
-     *
-     * @param string $refreshToken
-     *
-     * @return RefreshToken
-     */
-    public function setRefreshToken($refreshToken = null)
-    {
-        if (null == $refreshToken) {
-            $this->refreshToken = bin2hex(openssl_random_pseudo_bytes(64));
-        } else {
-            $this->refreshToken = $refreshToken;
-        }
-
-        return $this;
-    }
-
-    /**
-     * Get refreshToken.
-     *
-     * @return string
-     */
-    public function getRefreshToken()
-    {
-        return $this->refreshToken;
-    }
-
-    /**
-     * Set valid.
-     *
-     * @param \DateTime $valid
-     *
-     * @return RefreshToken
-     */
-    public function setValid($valid)
-    {
-        $this->valid = $valid;
-
-        return $this;
-    }
-
-    /**
-     * Get valid.
-     *
-     * @return \DateTime
-     */
-    public function getValid()
-    {
-        return $this->valid;
-    }
-
-    /**
-     * Set username.
-     *
-     * @param string $username
-     *
-     * @return RefreshToken
-     */
-    public function setUsername($username)
-    {
-        $this->username = $username;
-
-        return $this;
-    }
-
-    /**
-     * Get username.
-     *
-     * @return string
-     */
-    public function getUsername()
-    {
-        return $this->username;
-    }
-
-    /**
-     * Check if is a valid refresh token.
-     *
-     * @return bool
-     */
-    public function isValid()
-    {
-        $datetime = new \DateTime();
-
-        return ($this->valid >= $datetime) ? true : false;
-    }
-
-    /**
-     * @return string Refresh Token
-     */
-    public function __toString()
-    {
-        return $this->getRefreshToken();
+        $this->id;
     }
 }

--- a/Entity/RefreshToken.php
+++ b/Entity/RefreshToken.php
@@ -12,8 +12,6 @@
 namespace Gesdinet\JWTRefreshTokenBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Validator\Constraints as Assert;
-use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 /**

--- a/Entity/RefreshTokenRepository.php
+++ b/Entity/RefreshTokenRepository.php
@@ -3,6 +3,7 @@
 namespace Gesdinet\JWTRefreshTokenBundle\Entity;
 
 use Doctrine\ORM\EntityRepository;
+use Gesdinet\JWTRefreshTokenBundle\Service\RefreshToken;
 
 /**
  * RefreshTokenRepository.
@@ -12,6 +13,11 @@ use Doctrine\ORM\EntityRepository;
  */
 class RefreshTokenRepository extends EntityRepository
 {
+    /**
+     * @param null $datetime
+     *
+     * @return RefreshToken[]
+     */
     public function findInvalid($datetime = null)
     {
         $datetime = (null === $datetime) ? new \DateTime() : $datetime;

--- a/EventListener/AttachRefreshTokenOnSuccessListener.php
+++ b/EventListener/AttachRefreshTokenOnSuccessListener.php
@@ -12,7 +12,6 @@
 namespace Gesdinet\JWTRefreshTokenBundle\EventListener;
 
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManagerInterface;
-use Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken;
 use Gesdinet\JWTRefreshTokenBundle\Request\RequestRefreshToken;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\AuthenticationSuccessEvent;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -21,16 +20,40 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class AttachRefreshTokenOnSuccessListener
 {
-    protected $userRefreshTokenManager;
+    /**
+     * @var RefreshTokenManagerInterface
+     */
+    protected $refreshTokenManager;
 
+    /**
+     * @var int
+     */
     protected $ttl;
 
+    /**
+     * @var ValidatorInterface
+     */
     protected $validator;
 
+    /**
+     * @var RequestStack
+     */
     protected $requestStack;
 
-    public function __construct(RefreshTokenManagerInterface $refreshTokenManager, $ttl, ValidatorInterface $validator, RequestStack $requestStack)
-    {
+    /**
+     * AttachRefreshTokenOnSuccessListener constructor.
+     *
+     * @param RefreshTokenManagerInterface $refreshTokenManager
+     * @param $ttl
+     * @param ValidatorInterface $validator
+     * @param RequestStack $requestStack
+     */
+    public function __construct(
+        RefreshTokenManagerInterface $refreshTokenManager,
+        $ttl,
+        ValidatorInterface $validator,
+        RequestStack $requestStack
+    ) {
         $this->refreshTokenManager = $refreshTokenManager;
         $this->ttl = $ttl;
         $this->validator = $validator;

--- a/GesdinetJWTRefreshTokenBundle.php
+++ b/GesdinetJWTRefreshTokenBundle.php
@@ -3,6 +3,7 @@
 namespace Gesdinet\JWTRefreshTokenBundle;
 
 use Gesdinet\JWTRefreshTokenBundle\DependencyInjection\Compiler\CustomUserProviderCompilerPass;
+use Gesdinet\JWTRefreshTokenBundle\DependencyInjection\Compiler\DoctrineMappingsCompilerPass;
 use Gesdinet\JWTRefreshTokenBundle\DependencyInjection\Compiler\EntityManagerCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -15,5 +16,9 @@ class GesdinetJWTRefreshTokenBundle extends Bundle
 
         $container->addCompilerPass(new CustomUserProviderCompilerPass());
         $container->addCompilerPass(new EntityManagerCompilerPass());
+
+        if (class_exists('Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass')) {
+            $container->addCompilerPass(new DoctrineMappingsCompilerPass());
+        }
     }
 }

--- a/Model/RefreshTokenInterface.php
+++ b/Model/RefreshTokenInterface.php
@@ -58,7 +58,7 @@ interface RefreshTokenInterface
     /**
      * Set username.
      *
-     * @param $username
+     * @param string $username
      *
      * @return self
      */
@@ -67,7 +67,7 @@ interface RefreshTokenInterface
     /**
      * Get user.
      *
-     * @return $username
+     * @return string
      */
     public function getUsername();
 

--- a/Model/RefreshTokenManager.php
+++ b/Model/RefreshTokenManager.php
@@ -21,8 +21,7 @@ abstract class RefreshTokenManager implements RefreshTokenManagerInterface
     public function create()
     {
         $class = $this->getClass();
-        $token = new $class();
 
-        return $token;
+        return new $class();
     }
 }

--- a/README.md
+++ b/README.md
@@ -165,7 +165,11 @@ use Doctrine\ORM\Mapping as ORM;
 class JwtRefreshToken extends AbstractRefreshToken
 {
     /**
-     * @var string
+     * @var int
+     *
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
      */
     protected $id;
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Create the entity class extending `Gesdinet\JWTRefreshTokenBundle\Entity\Refresh
 ```php
 namespace MyBundle;
 
-use Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken as BaseRefreshToken;
+use Gesdinet\JWTRefreshTokenBundle\Entity\AbstractRefreshToken;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -162,8 +162,20 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity(repositoryClass="Gesdinet\JWTRefreshTokenBundle\Entity\RefreshTokenRepository")
  * @UniqueEntity("refreshToken")
  */
-class JwtRefreshToken extends BaseRefreshToken
+class JwtRefreshToken extends AbstractRefreshToken
 {
+    /**
+     * @var string
+     */
+    protected $id;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getId()
+    {
+        $this->id;
+    }
 }
 ```
 

--- a/Resources/config/doctrine-entity/RefreshToken.orm.yml
+++ b/Resources/config/doctrine-entity/RefreshToken.orm.yml
@@ -1,0 +1,10 @@
+Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken:
+  type: entity
+  table: refresh_tokens
+  repositoryClass: Gesdinet\JWTRefreshTokenBundle\Entity\RefreshTokenRepository
+  id:
+    id:
+      type: integer
+      column: id
+      generator:
+        strategy: AUTO

--- a/Resources/config/doctrine-orm/AbstractRefreshToken.orm.yml
+++ b/Resources/config/doctrine-orm/AbstractRefreshToken.orm.yml
@@ -1,0 +1,15 @@
+Gesdinet\JWTRefreshTokenBundle\Entity\AbstractRefreshToken:
+  type: mappedSuperclass
+  fields:
+    refreshToken:
+      type: string
+      column: refresh_token
+      length: 128
+      unique: true
+    username:
+      type: string
+      column: username
+      length: 255
+    valid:
+      type: datetime
+      column: valid

--- a/Resources/config/doctrine-superclass/RefreshToken.orm.yml
+++ b/Resources/config/doctrine-superclass/RefreshToken.orm.yml
@@ -1,0 +1,8 @@
+Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken:
+  type: mappedSuperclass
+  id:
+    id:
+      type: integer
+      column: id
+      generator:
+        strategy: AUTO

--- a/Security/Authenticator/RefreshTokenAuthenticator.php
+++ b/Security/Authenticator/RefreshTokenAuthenticator.php
@@ -61,7 +61,7 @@ class RefreshTokenAuthenticator extends RefreshTokenAuthenticatorBase implements
         $refreshToken = $token->getCredentials();
         $username = $userProvider->getUsernameForRefreshToken($refreshToken);
 
-        if (!$username) {
+        if ($username === null) {
             throw new AuthenticationException(
                 sprintf('Refresh token "%s" does not exist.', $refreshToken)
             );

--- a/Security/Provider/RefreshTokenProvider.php
+++ b/Security/Provider/RefreshTokenProvider.php
@@ -23,8 +23,14 @@ use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
  */
 class RefreshTokenProvider implements UserProviderInterface
 {
+    /**
+     * @var RefreshTokenManagerInterface
+     */
     protected $refreshTokenManager;
 
+    /**
+     * @var UserProviderInterface
+     */
     protected $customUserProvider;
 
     public function __construct(RefreshTokenManagerInterface $refreshTokenManager)
@@ -45,12 +51,12 @@ class RefreshTokenProvider implements UserProviderInterface
             return $refreshToken->getUsername();
         }
 
-        return;
+        return null;
     }
 
     public function loadUserByUsername($username)
     {
-        if (null != $this->customUserProvider) {
+        if (null !== $this->customUserProvider) {
             return $this->customUserProvider->loadUserByUsername($username);
         } else {
             return new User(
@@ -63,7 +69,7 @@ class RefreshTokenProvider implements UserProviderInterface
 
     public function refreshUser(UserInterface $user)
     {
-        if (null != $this->customUserProvider) {
+        if (null !== $this->customUserProvider) {
             return $this->customUserProvider->refreshUser($user);
         } else {
             throw new UnsupportedUserException();
@@ -72,7 +78,7 @@ class RefreshTokenProvider implements UserProviderInterface
 
     public function supportsClass($class)
     {
-        if (null != $this->customUserProvider) {
+        if (null !== $this->customUserProvider) {
             return $this->customUserProvider->supportsClass($class);
         } else {
             return 'Symfony\Component\Security\Core\User\User' === $class;

--- a/Service/RefreshToken.php
+++ b/Service/RefreshToken.php
@@ -12,12 +12,12 @@
 namespace Gesdinet\JWTRefreshTokenBundle\Service;
 
 use Symfony\Component\HttpFoundation\Request;
-use Lexik\Bundle\JWTAuthenticationBundle\Security\Http\Authentication\AuthenticationSuccessHandler;
-use Lexik\Bundle\JWTAuthenticationBundle\Security\Http\Authentication\AuthenticationFailureHandler;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManagerInterface;
 use Gesdinet\JWTRefreshTokenBundle\Security\Authenticator\RefreshTokenAuthenticator;
 use Gesdinet\JWTRefreshTokenBundle\Security\Provider\RefreshTokenProvider;
+use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
 
 /**
  * Class RefreshToken.
@@ -38,7 +38,7 @@ class RefreshToken
 
     private $ttlUpdate;
 
-    public function __construct(RefreshTokenAuthenticator $authenticator, RefreshTokenProvider $provider, AuthenticationSuccessHandler $successHandler, AuthenticationFailureHandler $failureHandler, RefreshTokenManagerInterface $refreshTokenManager, $ttl, $providerKey, $ttlUpdate)
+    public function __construct(RefreshTokenAuthenticator $authenticator, RefreshTokenProvider $provider, AuthenticationSuccessHandlerInterface $successHandler, AuthenticationFailureHandlerInterface $failureHandler, RefreshTokenManagerInterface $refreshTokenManager, $ttl, $providerKey, $ttlUpdate)
     {
         $this->authenticator = $authenticator;
         $this->provider = $provider;

--- a/Service/RefreshToken.php
+++ b/Service/RefreshToken.php
@@ -11,6 +11,7 @@
 
 namespace Gesdinet\JWTRefreshTokenBundle\Service;
 
+use InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManagerInterface;
@@ -24,22 +25,56 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerI
  */
 class RefreshToken
 {
+    /**
+     * @var RefreshTokenAuthenticator
+     */
     private $authenticator;
 
+    /**
+     * @var RefreshTokenProvider
+     */
     private $provider;
 
+    /**
+     * @var AuthenticationSuccessHandlerInterface 
+     */
     private $successHandler;
 
+    /**
+     * @var AuthenticationFailureHandlerInterface 
+     */
     private $failureHandler;
 
+    /**
+     * @var RefreshTokenManagerInterface 
+     */
     private $refreshTokenManager;
 
+    /**
+     * @var integer
+     */
     private $ttl;
 
+    /**
+     * @var string
+     */
+    private $providerKey;
+
+    /**
+     * @var bool
+     */
     private $ttlUpdate;
 
-    public function __construct(RefreshTokenAuthenticator $authenticator, RefreshTokenProvider $provider, AuthenticationSuccessHandlerInterface $successHandler, AuthenticationFailureHandlerInterface $failureHandler, RefreshTokenManagerInterface $refreshTokenManager, $ttl, $providerKey, $ttlUpdate)
-    {
+    public function __construct(
+        RefreshTokenAuthenticator $authenticator,
+        RefreshTokenProvider $provider,
+        AuthenticationSuccessHandlerInterface $successHandler,
+        AuthenticationFailureHandlerInterface $failureHandler,
+        RefreshTokenManagerInterface $refreshTokenManager,
+        $ttl,
+        $providerKey,
+        $ttlUpdate
+    ) {
         $this->authenticator = $authenticator;
         $this->provider = $provider;
         $this->successHandler = $successHandler;
@@ -57,13 +92,16 @@ class RefreshToken
      *
      * @return mixed
      *
+     * @throws InvalidArgumentException
      * @throws AuthenticationException
      */
     public function refresh(Request $request)
     {
         try {
             $preAuthenticatedToken = $this->authenticator->authenticateToken(
-                    $this->authenticator->createToken($request, $this->providerKey), $this->provider, $this->providerKey
+                $this->authenticator->createToken($request, $this->providerKey),
+                $this->provider,
+                $this->providerKey
             );
         } catch (AuthenticationException $e) {
             return $this->failureHandler->onAuthenticationFailure($request, $e);
@@ -73,8 +111,8 @@ class RefreshToken
 
         if (null === $refreshToken || !$refreshToken->isValid()) {
             return $this->failureHandler->onAuthenticationFailure($request, new AuthenticationException(
-                            sprintf('Refresh token "%s" is invalid.', $refreshToken)
-                            )
+                    sprintf('Refresh token "%s" is invalid.', $refreshToken)
+                )
             );
         }
 


### PR DESCRIPTION
This PR fixes #70, #51, #73.

It's based on PR #71 by @xthiago, but takes the idea even further and fixes more issues.

I use a set of different doctrine mapping configs in yml filex. Compiler pass checks if refresh_token_entity parameter is set.
If this parameter is not set, compiler pass will load an Entity mapping for built-in `RefreshToken` entity. The bundle will behave as usual - you get a ready to use entity stored in `refresh_tokens` table.
If this parameter is set, it will apply a MappedSuperclass mapping, allowing user to extend `AbstractRefreshToken` or `RefreshToken`. In this case user will be able to define table name of his choice and extra useless `refresh_tokens` table won't be created (#51).

P.S. We can also bump PHP version requirement to >=5.5.9 in composer.json, which is Symfony 3.0 requirement. It makes no sense to keep it at 5.3.3.