### PR TITLE
Replace deprecated configuration of routes with one colon

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Open your main routing configuration file (usually `app/config/routing.yml`) and
 # app/config/routing.yml
 gesdinet_jwt_refresh_token:
     path:     /api/token/refresh
-    defaults: { _controller: gesdinet.jwtrefreshtoken:refresh }
+    defaults: { _controller: gesdinet.jwtrefreshtoken::refresh }
 # ...
 ```
 


### PR DESCRIPTION
Hello.
Configuration of routes with one `:` was deprecated in Symfony 4.1: https://github.com/symfony/symfony/pull/26085