### PR TITLE
Check if manager_type option is defined before trying to get it in compiler pass

### DIFF
--- a/DependencyInjection/Compiler/DoctrineMappingsCompilerPass.php
+++ b/DependencyInjection/Compiler/DoctrineMappingsCompilerPass.php
@@ -27,7 +27,7 @@ final class DoctrineMappingsCompilerPass implements CompilerPassInterface
     {
         $config = $container->getExtensionConfig('gesdinet_jwt_refresh_token')[0];
 
-        $mappingPass = 'mongodb' === strtolower($config['manager_type'])
+        $mappingPass = isset($config['manager_type']) && 'mongodb' === strtolower($config['manager_type'])
             ? $this->getODMCompilerPass($config)
             : $this->getORMCompilerPass($config);
 


### PR DESCRIPTION
Hello,

I've encountered an issue that `Notice: Undefined index: manager_type` is thrown on compilation after changes from https://github.com/gesdinet/JWTRefreshTokenBundle/pull/108 when using ORM and when the `manager_type` is not specified in the configuration.

It's because in compiler pass default values are not set but only the configured values are taken into consideration. So the `$config['manager_type']`  is not set if I don't specify it explicitly in my configuration file.

This PR fixes it to keep the BC so that there is no need to explicitly add manager_type to the config.
