### PR TITLE
Fix commands deprecations

### DIFF
--- a/Command/ClearInvalidRefreshTokensCommand.php
+++ b/Command/ClearInvalidRefreshTokensCommand.php
@@ -11,7 +11,8 @@
 
 namespace Gesdinet\JWTRefreshTokenBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManagerInterface;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -19,19 +20,27 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * Class ClearInvalidRefreshTokensCommand.
  */
-class ClearInvalidRefreshTokensCommand extends ContainerAwareCommand
+class ClearInvalidRefreshTokensCommand extends Command
 {
+    protected static $defaultName = 'gesdinet:jwt:clear';
+
+    private $refreshTokenManager;
+
+    public function __construct(RefreshTokenManagerInterface $refreshTokenManager)
+    {
+        parent::__construct();
+
+        $this->refreshTokenManager = $refreshTokenManager;
+    }
+
     /**
      * @see Command
      */
     protected function configure()
     {
         $this
-            ->setName('gesdinet:jwt:clear')
             ->setDescription('Clear invalid refresh tokens.')
-            ->setDefinition(array(
-                new InputArgument('datetime', InputArgument::OPTIONAL),
-            ));
+            ->addArgument('datetime', InputArgument::OPTIONAL);
     }
 
     /**
@@ -47,8 +56,7 @@ class ClearInvalidRefreshTokensCommand extends ContainerAwareCommand
             $datetime = new \DateTime($datetime);
         }
 
-        $manager = $this->getContainer()->get('gesdinet.jwtrefreshtoken.refresh_token_manager');
-        $revokedTokens = $manager->revokeAllInvalid($datetime);
+        $revokedTokens = $this->refreshTokenManager->revokeAllInvalid($datetime);
 
         foreach ($revokedTokens as $revokedToken) {
             $output->writeln(sprintf('Revoke <comment>%s</comment>', $revokedToken->getRefreshToken()));

--- a/Command/RevokeRefreshTokenCommand.php
+++ b/Command/RevokeRefreshTokenCommand.php
@@ -11,7 +11,8 @@
 
 namespace Gesdinet\JWTRefreshTokenBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManagerInterface;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -19,19 +20,27 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * Class ClearInvalidRefreshTokensCommand.
  */
-class RevokeRefreshTokenCommand extends ContainerAwareCommand
+class RevokeRefreshTokenCommand extends Command
 {
+    protected static $defaultName = 'gesdinet:jwt:revoke';
+
+    private $refreshTokenManager;
+
+    public function __construct(RefreshTokenManagerInterface $refreshTokenManager)
+    {
+        parent::__construct();
+
+        $this->refreshTokenManager = $refreshTokenManager;
+    }
+
     /**
      * @see Command
      */
     protected function configure()
     {
         $this
-            ->setName('gesdinet:jwt:revoke')
             ->setDescription('Revoke a refresh token')
-            ->setDefinition(array(
-                new InputArgument('refresh_token', InputArgument::REQUIRED, 'The refresh token to revoke'),
-            ));
+            ->addArgument('refresh_token', InputArgument::REQUIRED, 'The refresh token to revoke');
     }
 
     /**
@@ -41,8 +50,7 @@ class RevokeRefreshTokenCommand extends ContainerAwareCommand
     {
         $refreshTokenParam = $input->getArgument('refresh_token');
 
-        $manager = $this->getContainer()->get('gesdinet.jwtrefreshtoken.refresh_token_manager');
-        $refreshToken = $manager->get($refreshTokenParam);
+        $refreshToken = $this->refreshTokenManager->get($refreshTokenParam);
 
         if (null === $refreshToken) {
             $output->writeln(sprintf('<error>Not Found:</error> Refresh Token <comment>%s</comment> doesn\'t exists', $refreshTokenParam));
@@ -50,7 +58,7 @@ class RevokeRefreshTokenCommand extends ContainerAwareCommand
             return -1;
         }
 
-        $manager->delete($refreshToken);
+        $this->refreshTokenManager->delete($refreshToken);
 
         $output->writeln(sprintf('Revoke <comment>%s</comment>', $refreshToken->getRefreshToken()));
     }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -26,3 +26,6 @@ services:
     Gesdinet\JWTRefreshTokenBundle\Command\:
         resource: '../../Command/*'
         tags: ['console.command']
+
+    Gesdinet\JWTRefreshTokenBundle\Command\ClearInvalidRefreshTokensCommand: ['@gesdinet.jwtrefreshtoken.refresh_token_manager']
+    Gesdinet\JWTRefreshTokenBundle\Command\RevokeRefreshTokenCommand: ['@gesdinet.jwtrefreshtoken.refresh_token_manager']

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
   ],
   "require" : {
     "php": ">=5.3.3",
-    "symfony/framework-bundle": "~3.3|~4.0",
-    "symfony/validator": "~3.3|~4.0",
+    "symfony/framework-bundle": "~3.4|~4.0",
+    "symfony/validator": "~3.4|~4.0",
     "lexik/jwt-authentication-bundle": "^1.1|^2.0@dev"
   },
   "require-dev": {

--- a/spec/Command/ClearInvalidRefreshTokensCommandSpec.php
+++ b/spec/Command/ClearInvalidRefreshTokensCommandSpec.php
@@ -8,10 +8,14 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class ClearInvalidRefreshTokensCommandSpec extends ObjectBehavior
 {
+    public function let(RefreshTokenManagerInterface $refreshTokenManager)
+    {
+        $this->beConstructedWith($refreshTokenManager);
+    }
+
     public function it_is_initializable()
     {
         $this->shouldHaveType('Gesdinet\JWTRefreshTokenBundle\Command\ClearInvalidRefreshTokensCommand');
@@ -19,7 +23,7 @@ class ClearInvalidRefreshTokensCommandSpec extends ObjectBehavior
 
     public function it_is_a_command()
     {
-        $this->shouldHaveType('Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand');
+        $this->shouldHaveType('Symfony\Component\Console\Command\Command');
     }
 
     public function it_has_a_name()
@@ -27,14 +31,12 @@ class ClearInvalidRefreshTokensCommandSpec extends ObjectBehavior
         $this->getName()->shouldReturn('gesdinet:jwt:clear');
     }
 
-    public function it_clears_invalid_refresh_tokens(ContainerInterface $container, InputInterface $input, OutputInterface $output, RefreshTokenManagerInterface $refreshTokenManager, RefreshTokenInterface $revokedToken)
+    public function it_clears_invalid_refresh_tokens(InputInterface $input, OutputInterface $output, RefreshTokenManagerInterface $refreshTokenManager, RefreshTokenInterface $revokedToken)
     {
-        $container->get('gesdinet.jwtrefreshtoken.refresh_token_manager')->shouldBeCalled()->willReturn($refreshTokenManager);
         $refreshTokenManager->revokeAllInvalid(Argument::any())->shouldBeCalled()->willReturn(array($revokedToken));
 
         $output->writeln(Argument::any())->shouldBeCalled();
 
-        $this->setContainer($container);
         $this->run($input, $output);
     }
 }

--- a/spec/Command/RevokeRefreshTokenCommandSpec.php
+++ b/spec/Command/RevokeRefreshTokenCommandSpec.php
@@ -8,10 +8,14 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class RevokeRefreshTokenCommandSpec extends ObjectBehavior
 {
+    public function let(RefreshTokenManagerInterface $refreshTokenManager)
+    {
+        $this->beConstructedWith($refreshTokenManager);
+    }
+
     public function it_is_initializable()
     {
         $this->shouldHaveType('Gesdinet\JWTRefreshTokenBundle\Command\RevokeRefreshTokenCommand');
@@ -19,7 +23,7 @@ class RevokeRefreshTokenCommandSpec extends ObjectBehavior
 
     public function it_is_a_command()
     {
-        $this->shouldHaveType('Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand');
+        $this->shouldHaveType('Symfony\Component\Console\Command\Command');
     }
 
     public function it_has_a_name()
@@ -27,24 +31,20 @@ class RevokeRefreshTokenCommandSpec extends ObjectBehavior
         $this->getName()->shouldReturn('gesdinet:jwt:revoke');
     }
 
-    public function it_revokes_a_refresh_token(ContainerInterface $container, InputInterface $input, OutputInterface $output, RefreshTokenManagerInterface $refreshTokenManager, RefreshTokenInterface $refreshToken)
+    public function it_revokes_a_refresh_token(InputInterface $input, OutputInterface $output, RefreshTokenManagerInterface $refreshTokenManager, RefreshTokenInterface $refreshToken)
     {
-        $container->get('gesdinet.jwtrefreshtoken.refresh_token_manager')->shouldBeCalled()->willReturn($refreshTokenManager);
         $refreshTokenManager->get(Argument::any())->shouldBeCalled()->willReturn($refreshToken);
 
         $refreshTokenManager->delete($refreshToken)->shouldBeCalled();
         $output->writeln(Argument::any())->shouldBeCalled();
 
-        $this->setContainer($container);
         $this->run($input, $output);
     }
 
-    public function it_not_revokes_a_refresh_token(ContainerInterface $container, InputInterface $input, OutputInterface $output, RefreshTokenManagerInterface $refreshTokenManager, RefreshTokenInterface $refreshToken)
+    public function it_not_revokes_a_refresh_token(InputInterface $input, OutputInterface $output, RefreshTokenManagerInterface $refreshTokenManager, RefreshTokenInterface $refreshToken)
     {
-        $container->get('gesdinet.jwtrefreshtoken.refresh_token_manager')->shouldBeCalled()->willReturn($refreshTokenManager);
         $refreshTokenManager->get(Argument::any())->shouldBeCalled()->willReturn(null);
 
-        $this->setContainer($container);
         $this->run($input, $output)->shouldBe(-1);
     }
 }


### PR DESCRIPTION
Partially fixes #124 (imho SimplePreAuthenticatorInterface deprecation should be in a separate PR)

Increased symfony dependencies to 3.4 because 3.3 is EOL'ed and 3.4 is a LTS release