### PR TITLE
Add ability to configure refresh token parameter name (#99)

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -57,6 +57,7 @@ class Configuration implements ConfigurationInterface
                     ->defaultNull()
                     ->info('Deprecated, use object_manager instead')
                     ->end()
+                ->scalarNode('token_parameter_name')->defaultValue('refresh_token')->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/GesdinetJWTRefreshTokenExtension.php
+++ b/DependencyInjection/GesdinetJWTRefreshTokenExtension.php
@@ -39,6 +39,7 @@ class GesdinetJWTRefreshTokenExtension extends Extension
         $container->setParameter('gesdinet_jwt_refresh_token.security.firewall', $config['firewall']);
         $container->setParameter('gesdinet_jwt_refresh_token.user_provider', $config['user_provider']);
         $container->setParameter('gesdinet_jwt_refresh_token.user_identity_field', $config['user_identity_field']);
+        $container->setParameter('gesdinet_jwt_refresh_token.token_parameter_name', $config['token_parameter_name']);
 
         $refreshTokenClass = 'Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken';
         $objectManager = 'doctrine.orm.entity_manager';

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ gesdinet_jwt_refresh_token:
 
 ### Config Refresh token parameter Name
 
-You can define refresh token parameter name. Default value is refresh_token. You can change this value adding this line to your config.yml file:
+You can define refresh token parameter name. Default value is refresh_token. You can change this value adding this line to your config file:
 
 ```yaml
 gesdinet_jwt_refresh_token:

--- a/README.md
+++ b/README.md
@@ -178,6 +178,15 @@ gesdinet_jwt_refresh_token:
     firewall: api
 ```
 
+### Config Refresh token parameter Name
+
+You can define refresh token parameter name. Default value is refresh_token. You can change this value adding this line to your config.yml file:
+
+```yaml
+gesdinet_jwt_refresh_token:
+    token_parameter_name: refreshToken
+```
+
 ### Config UserProvider
 
 You can define your own UserProvider. By default we use our custom UserProvider. You can change this value by adding this line to your config.yml file:

--- a/Request/RequestRefreshToken.php
+++ b/Request/RequestRefreshToken.php
@@ -15,15 +15,15 @@ use Symfony\Component\HttpFoundation\Request;
 
 class RequestRefreshToken
 {
-    public static function getRefreshToken(Request $request)
+    public static function getRefreshToken(Request $request, $tokenParameterName)
     {
         $refreshTokenString = null;
         if (false !== strpos($request->getContentType(), 'json')) {
             $content = $request->getContent();
             $params = !empty($content) ? json_decode($content, true) : array();
-            $refreshTokenString = isset($params['refresh_token']) ? trim($params['refresh_token']) : null;
-        } elseif (null !== $request->get('refresh_token')) {
-            $refreshTokenString = $request->get('refresh_token');
+            $refreshTokenString = isset($params[$tokenParameterName]) ? trim($params[$tokenParameterName]) : null;
+        } elseif (null !== $request->get($tokenParameterName)) {
+            $refreshTokenString = $request->get($tokenParameterName);
         }
 
         return $refreshTokenString;

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,7 +1,7 @@
 services:
     gesdinet.jwtrefreshtoken.send_token:
         class: Gesdinet\JWTRefreshTokenBundle\EventListener\AttachRefreshTokenOnSuccessListener
-        arguments: [ "@gesdinet.jwtrefreshtoken.refresh_token_manager", "%gesdinet_jwt_refresh_token.ttl%", "@validator", "@request_stack", "%gesdinet_jwt_refresh_token.user_identity_field%" ]
+        arguments: [ "@gesdinet.jwtrefreshtoken.refresh_token_manager", "%gesdinet_jwt_refresh_token.ttl%", "@validator", "@request_stack", "%gesdinet_jwt_refresh_token.user_identity_field%", "%gesdinet_jwt_refresh_token.token_parameter_name%" ]
         tags:
             - { name: kernel.event_listener, event: lexik_jwt_authentication.on_authentication_success, method: attachRefreshToken }
 
@@ -21,7 +21,7 @@ services:
 
     gesdinet.jwtrefreshtoken.authenticator:
         class: Gesdinet\JWTRefreshTokenBundle\Security\Authenticator\RefreshTokenAuthenticator
-        arguments: [ "@gesdinet.jwtrefreshtoken.user_checker" ]
+        arguments: [ "@gesdinet.jwtrefreshtoken.user_checker", "%gesdinet_jwt_refresh_token.token_parameter_name%" ]
 
     Gesdinet\JWTRefreshTokenBundle\Command\:
         resource: '../../Command/*'

--- a/Security/Authenticator/RefreshTokenAuthenticator.php
+++ b/Security/Authenticator/RefreshTokenAuthenticator.php
@@ -43,18 +43,25 @@ class RefreshTokenAuthenticator extends RefreshTokenAuthenticatorBase implements
     private $userChecker;
 
     /**
+     * @var string
+     */
+    protected $tokenParameterName;
+
+    /**
      * Constructor.
      *
      * @param UserCheckerInterface $userChecker
+     * @param string               $tokenParameterName
      */
-    public function __construct(UserCheckerInterface $userChecker)
+    public function __construct(UserCheckerInterface $userChecker, $tokenParameterName)
     {
         $this->userChecker = $userChecker;
+        $this->tokenParameterName = $tokenParameterName;
     }
 
     public function createToken(Request $request, $providerKey)
     {
-        $refreshTokenString = RequestRefreshToken::getRefreshToken($request);
+        $refreshTokenString = RequestRefreshToken::getRefreshToken($request, $this->tokenParameterName);
 
         return new PreAuthenticatedToken(
             '',

--- a/spec/EventListener/AttachRefreshTokenOnSuccessListenerSpec.php
+++ b/spec/EventListener/AttachRefreshTokenOnSuccessListenerSpec.php
@@ -17,11 +17,13 @@ use Symfony\Component\HttpFoundation\ParameterBag;
 
 class AttachRefreshTokenOnSuccessListenerSpec extends ObjectBehavior
 {
+    const TOKEN_PARAMETER_NAME = 'refresh_token';
+
     public function let(RefreshTokenManagerInterface $refreshTokenManager, ValidatorInterface $validator, RequestStack $requestStack)
     {
         $ttl = 2592000;
         $userIdentityField = 'username';
-        $this->beConstructedWith($refreshTokenManager, $ttl, $validator, $requestStack, $userIdentityField);
+        $this->beConstructedWith($refreshTokenManager, $ttl, $validator, $requestStack, $userIdentityField, self::TOKEN_PARAMETER_NAME);
     }
 
     public function it_is_initializable()
@@ -34,7 +36,7 @@ class AttachRefreshTokenOnSuccessListenerSpec extends ObjectBehavior
         $event->getData()->willReturn(array());
         $event->getUser()->willReturn($user);
 
-        $refreshTokenArray = array('refresh_token' => 'thepreviouslyissuedrefreshtoken');
+        $refreshTokenArray = array(self::TOKEN_PARAMETER_NAME => 'thepreviouslyissuedrefreshtoken');
         $headers = new HeaderBag(array('content_type' => 'not-json'));
         $request = new Request();
         $request->headers = $headers;

--- a/spec/Request/RequestRefreshTokenSpec.php
+++ b/spec/Request/RequestRefreshTokenSpec.php
@@ -7,43 +7,45 @@ use Symfony\Component\HttpFoundation\Request;
 
 class RequestRefreshTokenSpec extends ObjectBehavior
 {
+    const TOKEN_PARAMETER_NAME = 'refresh_token';
+
     public function it_gets_from_query_param()
     {
         $request = Request::createFromGlobals();
-        $request->attributes->set('refresh_token', 'abcd');
+        $request->attributes->set(self::TOKEN_PARAMETER_NAME, 'abcd');
 
-        $this::getRefreshToken($request)->shouldBe('abcd');
+        $this::getRefreshToken($request, self::TOKEN_PARAMETER_NAME)->shouldBe('abcd');
     }
 
     public function it_gets_from_body()
     {
         $request = Request::createFromGlobals();
-        $request->request->set('refresh_token', 'abcd');
+        $request->request->set(self::TOKEN_PARAMETER_NAME, 'abcd');
 
-        $this::getRefreshToken($request)->shouldBe('abcd');
+        $this::getRefreshToken($request, self::TOKEN_PARAMETER_NAME)->shouldBe('abcd');
     }
 
     public function it_gets_from_json()
     {
-        $request = Request::create(null, 'POST', array(), array(), array(), array(), json_encode(array('refresh_token' => 'abcd')));
+        $request = Request::create(null, 'POST', array(), array(), array(), array(), json_encode(array(self::TOKEN_PARAMETER_NAME => 'abcd')));
         $request->headers->set('content_type', 'application/json');
 
-        $this::getRefreshToken($request)->shouldBe('abcd');
+        $this::getRefreshToken($request, self::TOKEN_PARAMETER_NAME)->shouldBe('abcd');
     }
 
     public function it_gets_from_json_x()
     {
-        $request = Request::create(null, 'POST', array(), array(), array(), array(), json_encode(array('refresh_token' => 'abcd')));
+        $request = Request::create(null, 'POST', array(), array(), array(), array(), json_encode(array(self::TOKEN_PARAMETER_NAME => 'abcd')));
         $request->headers->set('content_type', 'application/x-json');
 
-        $this::getRefreshToken($request)->shouldBe('abcd');
+        $this::getRefreshToken($request, self::TOKEN_PARAMETER_NAME)->shouldBe('abcd');
     }
 
     public function it_gets_from_json_parameter()
     {
-        $request = Request::create(null, 'POST', array(), array(), array(), array(), json_encode(array('refresh_token' => 'abcd')));
+        $request = Request::create(null, 'POST', array(), array(), array(), array(), json_encode(array(self::TOKEN_PARAMETER_NAME => 'abcd')));
         $request->headers->set('content_type', 'application/json;charset=UTF-8');
 
-        $this::getRefreshToken($request)->shouldBe('abcd');
+        $this::getRefreshToken($request, self::TOKEN_PARAMETER_NAME)->shouldBe('abcd');
     }
 }

--- a/spec/Security/Authenticator/RefreshTokenAuthenticatorSpec.php
+++ b/spec/Security/Authenticator/RefreshTokenAuthenticatorSpec.php
@@ -12,7 +12,8 @@ class RefreshTokenAuthenticatorSpec extends ObjectBehavior
 {
     public function let(UserCheckerInterface $userChecker)
     {
-        $this->beConstructedWith($userChecker);
+        $tokenParameterName = 'refresh_token';
+        $this->beConstructedWith($userChecker, $tokenParameterName);
     }
 
     public function it_is_initializable()


### PR DESCRIPTION
In some use cases, ex. for better consistency in APIs with camelCase object fields naming.
So library could have parameter to customise refresh token field name.

- add optional parameter token_parameter_name to bundle configuration;
- update readme;
- fix phpspec tests;