### PR TITLE
Fix deprecation by using Guard instead of SimplePreAuthenticatorInterface

### DIFF
--- a/Event/RefreshEvent.php
+++ b/Event/RefreshEvent.php
@@ -13,7 +13,7 @@ namespace Gesdinet\JWTRefreshTokenBundle\Event;
 
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
 use Symfony\Component\EventDispatcher\Event;
-use Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken;
+use Symfony\Component\Security\Guard\Token\PostAuthenticationGuardToken;
 
 class RefreshEvent extends Event
 {
@@ -21,7 +21,7 @@ class RefreshEvent extends Event
 
     private $preAuthenticatedToken;
 
-    public function __construct(RefreshTokenInterface $refreshToken, PreAuthenticatedToken $preAuthenticatedToken)
+    public function __construct(RefreshTokenInterface $refreshToken, PostAuthenticationGuardToken $preAuthenticatedToken)
     {
         $this->refreshToken = $refreshToken;
         $this->preAuthenticatedToken = $preAuthenticatedToken;

--- a/Security/Authenticator/RefreshTokenAuthenticator.php
+++ b/Security/Authenticator/RefreshTokenAuthenticator.php
@@ -23,7 +23,6 @@ use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
 use Symfony\Component\HttpFoundation\Response;
 use Gesdinet\JWTRefreshTokenBundle\Security\Provider\RefreshTokenProvider;
 
-
 /**
  * Class RefreshTokenAuthenticator.
  */
@@ -44,7 +43,7 @@ class RefreshTokenAuthenticator extends AbstractGuardAuthenticator
      * Constructor.
      *
      * @param UserCheckerInterface $userChecker
-     * @param string $tokenParameterName
+     * @param string               $tokenParameterName
      */
     public function __construct(UserCheckerInterface $userChecker, $tokenParameterName)
     {
@@ -127,5 +126,4 @@ class RefreshTokenAuthenticator extends AbstractGuardAuthenticator
     {
         return false;
     }
-
 }

--- a/Security/Authenticator/RefreshTokenAuthenticator.php
+++ b/Security/Authenticator/RefreshTokenAuthenticator.php
@@ -27,7 +27,8 @@ use Gesdinet\JWTRefreshTokenBundle\Security\Provider\RefreshTokenProvider;
 /**
  * Class RefreshTokenAuthenticator.
  */
-class RefreshTokenAuthenticator extends AbstractGuardAuthenticator {
+class RefreshTokenAuthenticator extends AbstractGuardAuthenticator
+{
 
     /**
      * @var UserCheckerInterface
@@ -43,7 +44,7 @@ class RefreshTokenAuthenticator extends AbstractGuardAuthenticator {
      * Constructor.
      *
      * @param UserCheckerInterface $userChecker
-     * @param string               $tokenParameterName
+     * @param string $tokenParameterName
      */
     public function __construct(UserCheckerInterface $userChecker, $tokenParameterName)
     {
@@ -116,7 +117,7 @@ class RefreshTokenAuthenticator extends AbstractGuardAuthenticator {
     {
         $data = [
             // you might translate this message
-            'message' => 'Authentication Required'
+            'message' => 'Authentication Required',
         ];
 
         return new JsonResponse($data, Response::HTTP_UNAUTHORIZED);

--- a/Security/Authenticator/RefreshTokenAuthenticator.php
+++ b/Security/Authenticator/RefreshTokenAuthenticator.php
@@ -28,7 +28,6 @@ use Gesdinet\JWTRefreshTokenBundle\Security\Provider\RefreshTokenProvider;
  */
 class RefreshTokenAuthenticator extends AbstractGuardAuthenticator
 {
-
     /**
      * @var UserCheckerInterface
      */

--- a/spec/DependencyInjection/GesdinetJWTRefreshTokenExtensionSpec.php
+++ b/spec/DependencyInjection/GesdinetJWTRefreshTokenExtensionSpec.php
@@ -34,6 +34,9 @@ class GesdinetJWTRefreshTokenExtensionSpec extends ObjectBehavior
         });
         $container->addResource(Argument::any())->willReturn(null);
 
+        $container->removeBindings(Argument::any())->will(function () {
+        });
+
         $configs = array();
         $this->load($configs, $container);
     }

--- a/spec/Security/Authenticator/RefreshTokenAuthenticatorSpec.php
+++ b/spec/Security/Authenticator/RefreshTokenAuthenticatorSpec.php
@@ -4,7 +4,6 @@ namespace spec\Gesdinet\JWTRefreshTokenBundle\Security\Authenticator;
 
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 
@@ -21,10 +20,9 @@ class RefreshTokenAuthenticatorSpec extends ObjectBehavior
         $this->shouldHaveType('Gesdinet\JWTRefreshTokenBundle\Security\Authenticator\RefreshTokenAuthenticator');
     }
 
-    public function it_supports_token(PreAuthenticatedToken $token, $providerKey)
+    public function it_get_credentials(Request $request)
     {
-        $token->getProviderKey()->willReturn($providerKey);
-        $this->supports($token, $providerKey)->shouldBe(true);
+        $this->getCredentials($request)->shouldBeArray();
     }
 
     public function it_fails_on_authentication(Request $request, AuthenticationException $exception)

--- a/spec/Security/Authenticator/RefreshTokenAuthenticatorSpec.php
+++ b/spec/Security/Authenticator/RefreshTokenAuthenticatorSpec.php
@@ -24,7 +24,7 @@ class RefreshTokenAuthenticatorSpec extends ObjectBehavior
     public function it_supports_token(PreAuthenticatedToken $token, $providerKey)
     {
         $token->getProviderKey()->willReturn($providerKey);
-        $this->supportsToken($token, $providerKey)->shouldBe(true);
+        $this->supports($token, $providerKey)->shouldBe(true);
     }
 
     public function it_fails_on_authentication(Request $request, AuthenticationException $exception)

--- a/spec/Service/RefreshTokenSpec.php
+++ b/spec/Service/RefreshTokenSpec.php
@@ -12,13 +12,12 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\User\User;
 use Symfony\Component\Security\Guard\Token\PostAuthenticationGuardToken;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 class RefreshTokenSpec extends ObjectBehavior
 {
-    public function let(RefreshTokenAuthenticator $authenticator, RefreshTokenProvider $provider, AuthenticationSuccessHandler $successHandler, AuthenticationFailureHandler $failureHandler, RefreshTokenManagerInterface $refreshTokenManager, TokenInterface $token, UserProviderInterface $userProvider, $ttl, $providerKey, $ttlUpdate, EventDispatcherInterface $eventDispatcher)
+    public function let(RefreshTokenAuthenticator $authenticator, RefreshTokenProvider $provider, AuthenticationSuccessHandler $successHandler, AuthenticationFailureHandler $failureHandler, RefreshTokenManagerInterface $refreshTokenManager, EventDispatcherInterface $eventDispatcher)
     {
         $ttl = 2592000;
         $ttlUpdate = false;
@@ -34,9 +33,9 @@ class RefreshTokenSpec extends ObjectBehavior
 
     public function it_refresh_token(Request $request, $refreshTokenManager, $authenticator, $token, PostAuthenticationGuardToken $postAuthenticationGuardToken, RefreshTokenInterface $refreshToken)
     {
-        $authenticator->createToken(Argument::any(), Argument::any())->willReturn($token);
-        $authenticator->authenticateToken(Argument::any(), Argument::any(), Argument::any())->willReturn($postAuthenticationGuardToken);
-
+        $authenticator->getCredentials(Argument::any())->willReturn(['token' => '1234']);
+        $authenticator->getUser(Argument::any(), Argument::any())->willReturn(new User('test', 'test'));
+        $authenticator->createAuthenticatedToken(Argument::any(), Argument::any())->willReturn($postAuthenticationGuardToken);
         $refreshTokenManager->get(Argument::any())->willReturn($refreshToken);
         $refreshToken->isValid()->willReturn(true);
 
@@ -47,8 +46,9 @@ class RefreshTokenSpec extends ObjectBehavior
     {
         $this->beConstructedWith($authenticator, $provider, $successHandler, $failureHandler, $refreshTokenManager, 2592000, 'testkey', true, $eventDispatcher);
 
-        $authenticator->createToken(Argument::any(), Argument::any())->willReturn($token);
-        $authenticator->authenticateToken(Argument::any(), Argument::any(), Argument::any())->willReturn($postAuthenticationGuardToken);
+        $authenticator->getCredentials(Argument::any())->willReturn(['token' => '1234']);
+        $authenticator->getUser(Argument::any(), Argument::any())->willReturn(new User('test', 'test'));
+        $authenticator->createAuthenticatedToken(Argument::any(), Argument::any())->willReturn($postAuthenticationGuardToken);
 
         $refreshTokenManager->get(Argument::any())->willReturn($refreshToken);
         $refreshToken->isValid()->willReturn(true);
@@ -59,10 +59,11 @@ class RefreshTokenSpec extends ObjectBehavior
         $this->refresh($request);
     }
 
-    public function it_throws_an_authentication_exception(Request $request, $refreshTokenManager, $authenticator, $token, PostAuthenticationGuardToken $postAuthenticationGuardToken, RefreshTokenInterface $refreshToken, $failureHandler)
+    public function it_throws_an_authentication_exception(Request $request, $authenticator, PostAuthenticationGuardToken $postAuthenticationGuardToken, $failureHandler)
     {
-        $authenticator->createToken(Argument::any(), Argument::any())->willReturn($token);
-        $authenticator->authenticateToken(Argument::any(), Argument::any(), Argument::any())->willReturn($postAuthenticationGuardToken);
+        $authenticator->getCredentials(Argument::any())->willReturn(['token' => '1234']);
+        $authenticator->getUser(Argument::any(), Argument::any())->willReturn(new User('test', 'test'));
+        $authenticator->createAuthenticatedToken(Argument::any(), Argument::any())->willReturn($postAuthenticationGuardToken);
 
         $failureHandler->onAuthenticationFailure(Argument::any(), Argument::any())->shouldBeCalled();
 

--- a/spec/Service/RefreshTokenSpec.php
+++ b/spec/Service/RefreshTokenSpec.php
@@ -12,7 +12,7 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken;
+use Symfony\Component\Security\Guard\Token\PostAuthenticationGuardToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
@@ -32,10 +32,10 @@ class RefreshTokenSpec extends ObjectBehavior
         $this->shouldHaveType('Gesdinet\JWTRefreshTokenBundle\Service\RefreshToken');
     }
 
-    public function it_refresh_token(Request $request, $refreshTokenManager, $authenticator, $token, PreAuthenticatedToken $preAuthenticatedToken, RefreshTokenInterface $refreshToken)
+    public function it_refresh_token(Request $request, $refreshTokenManager, $authenticator, $token, PostAuthenticationGuardToken $postAuthenticationGuardToken, RefreshTokenInterface $refreshToken)
     {
         $authenticator->createToken(Argument::any(), Argument::any())->willReturn($token);
-        $authenticator->authenticateToken(Argument::any(), Argument::any(), Argument::any())->willReturn($preAuthenticatedToken);
+        $authenticator->authenticateToken(Argument::any(), Argument::any(), Argument::any())->willReturn($postAuthenticationGuardToken);
 
         $refreshTokenManager->get(Argument::any())->willReturn($refreshToken);
         $refreshToken->isValid()->willReturn(true);
@@ -43,12 +43,12 @@ class RefreshTokenSpec extends ObjectBehavior
         $this->refresh($request);
     }
 
-    public function it_refresh_token_with_ttl_update(RefreshTokenProvider $provider, AuthenticationSuccessHandler $successHandler, AuthenticationFailureHandler $failureHandler, Request $request, $refreshTokenManager, $authenticator, $token, PreAuthenticatedToken $preAuthenticatedToken, RefreshTokenInterface $refreshToken, EventDispatcherInterface $eventDispatcher)
+    public function it_refresh_token_with_ttl_update(RefreshTokenProvider $provider, AuthenticationSuccessHandler $successHandler, AuthenticationFailureHandler $failureHandler, Request $request, $refreshTokenManager, $authenticator, $token, PostAuthenticationGuardToken $postAuthenticationGuardToken, RefreshTokenInterface $refreshToken, EventDispatcherInterface $eventDispatcher)
     {
         $this->beConstructedWith($authenticator, $provider, $successHandler, $failureHandler, $refreshTokenManager, 2592000, 'testkey', true, $eventDispatcher);
 
         $authenticator->createToken(Argument::any(), Argument::any())->willReturn($token);
-        $authenticator->authenticateToken(Argument::any(), Argument::any(), Argument::any())->willReturn($preAuthenticatedToken);
+        $authenticator->authenticateToken(Argument::any(), Argument::any(), Argument::any())->willReturn($postAuthenticationGuardToken);
 
         $refreshTokenManager->get(Argument::any())->willReturn($refreshToken);
         $refreshToken->isValid()->willReturn(true);
@@ -59,10 +59,10 @@ class RefreshTokenSpec extends ObjectBehavior
         $this->refresh($request);
     }
 
-    public function it_throws_an_authentication_exception(Request $request, $refreshTokenManager, $authenticator, $token, PreAuthenticatedToken $preAuthenticatedToken, RefreshTokenInterface $refreshToken, $failureHandler)
+    public function it_throws_an_authentication_exception(Request $request, $refreshTokenManager, $authenticator, $token, PostAuthenticationGuardToken $postAuthenticationGuardToken, RefreshTokenInterface $refreshToken, $failureHandler)
     {
         $authenticator->createToken(Argument::any(), Argument::any())->willReturn($token);
-        $authenticator->authenticateToken(Argument::any(), Argument::any(), Argument::any())->willReturn($preAuthenticatedToken);
+        $authenticator->authenticateToken(Argument::any(), Argument::any(), Argument::any())->willReturn($postAuthenticationGuardToken);
 
         $failureHandler->onAuthenticationFailure(Argument::any(), Argument::any())->shouldBeCalled();
 


### PR DESCRIPTION
Resolve the following deprecation : 
The "Gesdinet\JWTRefreshTokenBundle\Security\Authenticator\RefreshTokenAuthenticatorBase" class implements "Symfony\Component\Security\Http\Authentication\SimplePreAuthenticatorInterface" that is deprecated since Symfony 4.2, use Guard instead.

