### PR TITLE
Added Single Use config option

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -60,7 +60,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('single_use')
                     ->defaultFalse()
                     ->info('When true, generate a new refresh token on consumption (deleting the old one)')
-                ->end()
+                    ->end()
                 ->scalarNode('token_parameter_name')->defaultValue('refresh_token')->end()
             ->end();
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -57,6 +57,10 @@ class Configuration implements ConfigurationInterface
                     ->defaultNull()
                     ->info('Deprecated, use object_manager instead')
                     ->end()
+                ->scalarNode('single_use')
+                    ->defaultFalse()
+                    ->info('When true, generate a new refresh token on consumption (deleting the old one)')
+                ->end()
                 ->scalarNode('token_parameter_name')->defaultValue('refresh_token')->end()
             ->end();
 

--- a/DependencyInjection/GesdinetJWTRefreshTokenExtension.php
+++ b/DependencyInjection/GesdinetJWTRefreshTokenExtension.php
@@ -39,6 +39,7 @@ class GesdinetJWTRefreshTokenExtension extends Extension
         $container->setParameter('gesdinet_jwt_refresh_token.security.firewall', $config['firewall']);
         $container->setParameter('gesdinet_jwt_refresh_token.user_provider', $config['user_provider']);
         $container->setParameter('gesdinet_jwt_refresh_token.user_identity_field', $config['user_identity_field']);
+        $container->setParameter('gesdinet_jwt_refresh_token.single_use', $config['single_use']);
         $container->setParameter('gesdinet_jwt_refresh_token.token_parameter_name', $config['token_parameter_name']);
 
         $refreshTokenClass = 'Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken';

--- a/EventListener/AttachRefreshTokenOnSuccessListener.php
+++ b/EventListener/AttachRefreshTokenOnSuccessListener.php
@@ -97,7 +97,7 @@ class AttachRefreshTokenOnSuccessListener
 
         $refreshTokenString = RequestRefreshToken::getRefreshToken($request, $this->tokenParameterName);
 
-        if ($refreshTokenString && $this->singleUse === true) {
+        if ($refreshTokenString && true === $this->singleUse) {
             $refreshToken = $this->refreshTokenManager->get($refreshTokenString);
             $refreshTokenString = null;
 

--- a/EventListener/AttachRefreshTokenOnSuccessListener.php
+++ b/EventListener/AttachRefreshTokenOnSuccessListener.php
@@ -66,6 +66,7 @@ class AttachRefreshTokenOnSuccessListener
      * @param RequestStack                 $requestStack
      * @param string                       $userIdentityField
      * @param string                       $tokenParameterName
+     * @param bool                         $singleUse
      */
     public function __construct(
         RefreshTokenManagerInterface $refreshTokenManager,

--- a/README.md
+++ b/README.md
@@ -347,7 +347,9 @@ This refresh token is persisted in RefreshToken entity. After that, when your JW
 
 - Send you user credentials again to /api/login_check. This generates another JWT with another Refresh Token.
 
-- Ask to renew valid JWT with our refresh token. Make a POST call to /api/token/refresh url with refresh token as payload. In this way, you can always get a valid JWT without asking for user credentials. But **you must notice** if refresh token is still valid. Your refresh token do not change but valid datetime will increase unless the configuration option `single_use` is set to `true`.
+- Ask to renew valid JWT with our refresh token. Make a POST call to /api/token/refresh url with refresh token as payload. In this way, you can always get a valid JWT without asking for user credentials. But **you must notice** if refresh token is still valid. Your refresh token do not change but valid datetime will increase unless.
+
+***Note that when a refresh token is consumed and the config option `single_use` is set to `true` the token will no longer be valid.***
 
 ```bash
 curl -X POST -d refresh_token="xxxx4b54b0076d2fcc5a51a6e60c0fb83b0bc90b47e2c886accb70850795fb311973c9d101fa0111f12eec739db063ec09d7dd79331e3148f5fc6e9cb362xxxx" 'http://xxxx/token/refresh'

--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ USAGE
 The configurations can be put in:
 
 **Symfony 3 Version:** `app/config`  
-**Symfony 4 Version:** `config/packages/gesdinet_jwt_refresh_token.yaml`
+**Symfony 4 Version:** `config/packages/gesdinet_jwt_refresh_
+.yaml`
 
 ### Config TTL
 
@@ -230,6 +231,17 @@ gesdinet_jwt_refresh_token:
 ```
 
 You will probably want to use a custom UserProvider along with your UserChecker to ensure that the checker recieves the right type of user.
+
+### Config Single Use
+
+You can configure the refresh token so it can only be consumed _once_. If set to `true` and the refresh token is consumed, a new refresh token will be provided. 
+
+To enable this behavior add this line to your config:
+
+```yaml
+gesdinet_jwt_refresh_token:
+    single_use: true
+```
 
 
 ### Use another entity for refresh tokens
@@ -335,7 +347,7 @@ This refresh token is persisted in RefreshToken entity. After that, when your JW
 
 - Send you user credentials again to /api/login_check. This generates another JWT with another Refresh Token.
 
-- Ask to renew valid JWT with our refresh token. Make a POST call to /api/token/refresh url with refresh token as payload. In this way, you can always get a valid JWT without asking for user credentials. But **you must notice** if refresh token is still valid. Your refresh token do not change but valid datetime will increase.
+- Ask to renew valid JWT with our refresh token. Make a POST call to /api/token/refresh url with refresh token as payload. In this way, you can always get a valid JWT without asking for user credentials. But **you must notice** if refresh token is still valid. Your refresh token do not change but valid datetime will increase unless the configuration option `single_use` is set to `true`.
 
 ```bash
 curl -X POST -d refresh_token="xxxx4b54b0076d2fcc5a51a6e60c0fb83b0bc90b47e2c886accb70850795fb311973c9d101fa0111f12eec739db063ec09d7dd79331e3148f5fc6e9cb362xxxx" 'http://xxxx/token/refresh'

--- a/README.md
+++ b/README.md
@@ -151,8 +151,7 @@ USAGE
 The configurations can be put in:
 
 **Symfony 3 Version:** `app/config`  
-**Symfony 4 Version:** `config/packages/gesdinet_jwt_refresh_
-.yaml`
+**Symfony 4 Version:** `config/packages/gesdinet_jwt_refresh_token.yaml`
 
 ### Config TTL
 
@@ -347,7 +346,7 @@ This refresh token is persisted in RefreshToken entity. After that, when your JW
 
 - Send you user credentials again to /api/login_check. This generates another JWT with another Refresh Token.
 
-- Ask to renew valid JWT with our refresh token. Make a POST call to /api/token/refresh url with refresh token as payload. In this way, you can always get a valid JWT without asking for user credentials. But **you must notice** if refresh token is still valid. Your refresh token do not change but valid datetime will increase unless.
+- Ask to renew valid JWT with our refresh token. Make a POST call to /api/token/refresh url with refresh token as payload. In this way, you can always get a valid JWT without asking for user credentials. But **you must notice** if refresh token is still valid. Your refresh token do not change but valid datetime will increase.
 
 ***Note that when a refresh token is consumed and the config option `single_use` is set to `true` the token will no longer be valid.***
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,7 +1,7 @@
 services:
     gesdinet.jwtrefreshtoken.send_token:
         class: Gesdinet\JWTRefreshTokenBundle\EventListener\AttachRefreshTokenOnSuccessListener
-        arguments: [ "@gesdinet.jwtrefreshtoken.refresh_token_manager", "%gesdinet_jwt_refresh_token.ttl%", "@validator", "@request_stack", "%gesdinet_jwt_refresh_token.user_identity_field%", "%gesdinet_jwt_refresh_token.token_parameter_name%", "%gesdinet_jwt_refresh_token.single_use%"]
+        arguments: [ "@gesdinet.jwtrefreshtoken.refresh_token_manager", "%gesdinet_jwt_refresh_token.ttl%", "@validator", "@request_stack", "%gesdinet_jwt_refresh_token.user_identity_field%", "%gesdinet_jwt_refresh_token.token_parameter_name%", "%gesdinet_jwt_refresh_token.single_use%" ]
         tags:
             - { name: kernel.event_listener, event: lexik_jwt_authentication.on_authentication_success, method: attachRefreshToken }
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,7 +1,7 @@
 services:
     gesdinet.jwtrefreshtoken.send_token:
         class: Gesdinet\JWTRefreshTokenBundle\EventListener\AttachRefreshTokenOnSuccessListener
-        arguments: [ "@gesdinet.jwtrefreshtoken.refresh_token_manager", "%gesdinet_jwt_refresh_token.ttl%", "@validator", "@request_stack", "%gesdinet_jwt_refresh_token.user_identity_field%", "%gesdinet_jwt_refresh_token.token_parameter_name%" ]
+        arguments: [ "@gesdinet.jwtrefreshtoken.refresh_token_manager", "%gesdinet_jwt_refresh_token.ttl%", "@validator", "@request_stack", "%gesdinet_jwt_refresh_token.user_identity_field%", "%gesdinet_jwt_refresh_token.token_parameter_name%", "%gesdinet_jwt_refresh_token.single_use%"]
         tags:
             - { name: kernel.event_listener, event: lexik_jwt_authentication.on_authentication_success, method: attachRefreshToken }
 

--- a/spec/DependencyInjection/GesdinetJWTRefreshTokenExtensionSpec.php
+++ b/spec/DependencyInjection/GesdinetJWTRefreshTokenExtensionSpec.php
@@ -33,6 +33,7 @@ class GesdinetJWTRefreshTokenExtensionSpec extends ObjectBehavior
             return new \ReflectionClass($args[0]);
         });
         $container->addResource(Argument::any())->willReturn(null);
+        $container->addRemovedBindingIds(Argument::any())->willReturn(null);
 
         $configs = array();
         $this->load($configs, $container);

--- a/spec/EventListener/AttachRefreshTokenOnSuccessListenerSpec.php
+++ b/spec/EventListener/AttachRefreshTokenOnSuccessListenerSpec.php
@@ -23,7 +23,8 @@ class AttachRefreshTokenOnSuccessListenerSpec extends ObjectBehavior
     {
         $ttl = 2592000;
         $userIdentityField = 'username';
-        $this->beConstructedWith($refreshTokenManager, $ttl, $validator, $requestStack, $userIdentityField, self::TOKEN_PARAMETER_NAME);
+        $singleUse = false;
+        $this->beConstructedWith($refreshTokenManager, $ttl, $validator, $requestStack, $userIdentityField, self::TOKEN_PARAMETER_NAME, $singleUse);
     }
 
     public function it_is_initializable()


### PR DESCRIPTION
When a refresh token is consumed and the config option `single_use` is set to `true` the token will no longer be valid.