### PR TITLE
Remove Symfony 4.3 deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,11 @@ matrix:
       env: SYMFONY_VERSION=3.4.*
     - php: 7.2
       env: SYMFONY_VERSION=3.4.*
-      # 4.2.*
+      # 4.3.*
     - php: 7.1
-      env: SYMFONY_VERSION=4.2.*
+      env: SYMFONY_VERSION=4.3.*
     - php: 7.2
-      env: SYMFONY_VERSION=4.2.*
+      env: SYMFONY_VERSION=4.3.*
 
 cache:
   directories:

--- a/Event/Event.php
+++ b/Event/Event.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Gesdinet\JWTRefreshTokenBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event as BaseEvent;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Contracts\EventDispatcher\Event as ContractsBaseEvent;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+if (is_subclass_of(EventDispatcher::class, EventDispatcherInterface::class)) {
+    class Event extends ContractsBaseEvent
+    {
+    }
+} else {
+    class Event extends BaseEvent
+    {
+    }
+}

--- a/Event/RefreshEvent.php
+++ b/Event/RefreshEvent.php
@@ -12,7 +12,6 @@
 namespace Gesdinet\JWTRefreshTokenBundle\Event;
 
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
-use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\Security\Guard\Token\PostAuthenticationGuardToken;
 
 class RefreshEvent extends Event

--- a/Service/RefreshToken.php
+++ b/Service/RefreshToken.php
@@ -14,6 +14,7 @@ namespace Gesdinet\JWTRefreshTokenBundle\Service;
 use Gesdinet\JWTRefreshTokenBundle\Event\RefreshEvent;
 use Gesdinet\JWTRefreshTokenBundle\Security\Authenticator\RefreshTokenAuthenticator;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
 use InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -147,7 +148,11 @@ class RefreshToken
             $this->refreshTokenManager->save($refreshToken);
         }
 
-        $this->eventDispatcher->dispatch('gesdinet.refresh_token', new RefreshEvent($refreshToken, $postAuthenticationToken));
+        if ($this->eventDispatcher instanceof ContractsEventDispatcherInterface) {
+            $this->eventDispatcher->dispatch(new RefreshEvent($refreshToken, $postAuthenticationToken), 'gesdinet.refresh_token');
+        } else {
+            $this->eventDispatcher->dispatch('gesdinet.refresh_token', new RefreshEvent($refreshToken, $postAuthenticationToken));
+        }
 
         return $this->successHandler->onAuthenticationSuccess($request, $postAuthenticationToken);
     }


### PR DESCRIPTION
Symfony 4.3 has deprecated a few things related to events. This patch removes these deprecations while keeping BC with previous symfony versions