### PR TITLE
Update example objects to keep default table name

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ use Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken as BaseRefreshToken;
 
 /**
  * @ORM\Entity
+ * @ORM\Table("refresh_tokens")
  */
 class RefreshToken extends BaseRefreshToken
 {
@@ -119,7 +120,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Gesdinet\JWTRefreshTokenBundle\Document\RefreshToken as BaseRefreshToken;
 
 /**
- * @ODM\Document
+ * @ODM\Document(collection="refresh_tokens")
  */
 class RefreshToken extends BaseRefreshToken
 {


### PR DESCRIPTION
As spotted in https://github.com/symfony/recipes-contrib/pull/1390#discussion_r847334381 the object annotations need to specify the table name used in the XML mapping otherwise the name will be automatically computed and the object will end up using a different table name.  This is somewhat more important for existing apps updating to 1.1 as we don't want them to have a needless migration to rename their table.