### PR TITLE
Delete with DQL so that rows-affected can be returned

### DIFF
--- a/src/Doctrine/RefreshTokenManager.php
+++ b/src/Doctrine/RefreshTokenManager.php
@@ -78,7 +78,7 @@ final readonly class RefreshTokenManager implements RefreshTokenManagerInterface
      */
     private function deleteById(\Doctrine\ORM\EntityManagerInterface|MockObject $entityManager, int $id): int
     {
-        $q = $entityManager->createQuery('DELETE FROM Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken rt WHERE rt.id = :id');
+        $q = $entityManager->createQuery(sprintf('DELETE FROM %s rt WHERE rt.id = :id', $this->class));
         $q->setParameter('id', $id);
         $numDeleted = $q->execute();
 

--- a/src/Doctrine/RefreshTokenManager.php
+++ b/src/Doctrine/RefreshTokenManager.php
@@ -74,8 +74,6 @@ final readonly class RefreshTokenManager implements RefreshTokenManagerInterface
     /**
      * Wrapper around DQL deletion so that ObjectManager can be cast to EntityManagerInterface.
      *
-     * @param \Doctrine\ORM\EntityManagerInterface|MockObject $entityManager
-     * @param int $id
      * @return int Number of rows deleted
      */
     private function deleteById(\Doctrine\ORM\EntityManagerInterface|MockObject $entityManager, int $id): int

--- a/src/Doctrine/RefreshTokenManager.php
+++ b/src/Doctrine/RefreshTokenManager.php
@@ -72,16 +72,18 @@ final readonly class RefreshTokenManager implements RefreshTokenManagerInterface
     }
 
     /**
-     * Wrapper around DQL deletion so that ObjectManager can be cast to EntityManagerInterface
+     * Wrapper around DQL deletion so that ObjectManager can be cast to EntityManagerInterface.
      *
      * @param \Doctrine\ORM\EntityManagerInterface|MockObject $entityManager
      * @param int $id
      * @return int Number of rows deleted
      */
-    private function deleteById(\Doctrine\ORM\EntityManagerInterface|MockObject $entityManager, int $id): int {
+    private function deleteById(\Doctrine\ORM\EntityManagerInterface|MockObject $entityManager, int $id): int
+    {
         $q = $entityManager->createQuery('DELETE FROM Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken rt WHERE rt.id = :id');
         $q->setParameter('id', $id);
         $numDeleted = $q->execute();
+
         return $numDeleted;
     }
 
@@ -107,6 +109,7 @@ final readonly class RefreshTokenManager implements RefreshTokenManagerInterface
             if ($andFlush) {
                 $this->objectManager->flush();
             }
+
             return $numDeleted;
         }
 

--- a/src/Doctrine/RefreshTokenManager.php
+++ b/src/Doctrine/RefreshTokenManager.php
@@ -12,6 +12,7 @@
 namespace Gesdinet\JWTRefreshTokenBundle\Doctrine;
 
 use Doctrine\Persistence\ObjectManager;
+use Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken;
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManagerInterface;
 use LogicException;
@@ -77,7 +78,7 @@ final readonly class RefreshTokenManager implements RefreshTokenManagerInterface
      */
     private function deleteById(\Doctrine\ORM\EntityManagerInterface $entityManager, int $id): int
     {
-        $q = $entityManager->createQuery(sprintf('DELETE FROM %s rt WHERE rt.id = :id', $this->class));
+        $q = $entityManager->createQuery(sprintf('DELETE FROM %s rt WHERE rt.id = :id', RefreshToken::class));
         $q->setParameter('id', $id);
         $numDeleted = $q->execute();
 

--- a/src/Doctrine/RefreshTokenManager.php
+++ b/src/Doctrine/RefreshTokenManager.php
@@ -16,7 +16,6 @@ use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManagerInterface;
 use LogicException;
 use DateTimeInterface;
-use PHPUnit\Framework\MockObject\MockObject;
 
 final readonly class RefreshTokenManager implements RefreshTokenManagerInterface
 {
@@ -76,7 +75,7 @@ final readonly class RefreshTokenManager implements RefreshTokenManagerInterface
      *
      * @return int Number of rows deleted
      */
-    private function deleteById(\Doctrine\ORM\EntityManagerInterface|MockObject $entityManager, int $id): int
+    private function deleteById(\Doctrine\ORM\EntityManagerInterface $entityManager, int $id): int
     {
         $q = $entityManager->createQuery(sprintf('DELETE FROM %s rt WHERE rt.id = :id', $this->class));
         $q->setParameter('id', $id);
@@ -93,10 +92,7 @@ final readonly class RefreshTokenManager implements RefreshTokenManagerInterface
     public function delete(RefreshTokenInterface $refreshToken, bool $andFlush = true): int
     {
         // Use DQL if this is an ORM EntityManager
-        if (
-            $this->objectManager instanceof \Doctrine\ORM\EntityManagerInterface ||
-            (is_object($this->objectManager) && str_contains(get_class($this->objectManager), 'MockObject_ObjectManager'))
-        ) {
+        if ($this->objectManager instanceof \Doctrine\ORM\EntityManagerInterface) {
             $repository = $this->objectManager->getRepository($this->class);
 
             if (!$repository instanceof RefreshTokenRepositoryInterface) {

--- a/tests/Unit/Doctrine/RefreshTokenManagerTest.php
+++ b/tests/Unit/Doctrine/RefreshTokenManagerTest.php
@@ -168,7 +168,7 @@ class RefreshTokenManagerTest extends TestCase
         $query = $this->getMockBuilder(Query::class)
             ->disableOriginalConstructor()
             ->getMock();
-        
+
         $query
             ->method('execute')
             ->willReturn(1);

--- a/tests/Unit/Doctrine/RefreshTokenManagerTest.php
+++ b/tests/Unit/Doctrine/RefreshTokenManagerTest.php
@@ -2,6 +2,8 @@
 
 namespace Gesdinet\JWTRefreshTokenBundle\Tests\Unit\Doctrine;
 
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
 use Gesdinet\JWTRefreshTokenBundle\Doctrine\RefreshTokenManager;
@@ -20,7 +22,11 @@ class RefreshTokenManagerTest extends TestCase
 
     private MockObject&ObjectManager $objectManager;
 
+    private MockObject&EntityManagerInterface $entityManager;
+
     private RefreshTokenManager $refreshTokenManager;
+
+    private RefreshTokenManager $refreshTokenManagerAlt;
 
     protected function setUp(): void
     {
@@ -48,6 +54,33 @@ class RefreshTokenManagerTest extends TestCase
 
         $this->refreshTokenManager = new RefreshTokenManager(
             $this->objectManager,
+            static::REFRESH_TOKEN_ENTITY_CLASS,
+            RefreshTokenManagerInterface::DEFAULT_BATCH_SIZE,
+        );
+
+        // alt setup for EntityManagerInterface (subclass of ObjectManager), required in testDeletesTheRefreshTokenAndFlushesTheObjectManager()
+        $classMetadataAlt = $this->createMock(\Doctrine\ORM\Mapping\ClassMetadata::class);
+        $classMetadataAlt
+            ->expects($this->once())
+            ->method('getName')
+            ->willReturn(static::REFRESH_TOKEN_ENTITY_CLASS);
+
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        // Allow getRepository to be called any number of times with the expected argument
+        $this->entityManager
+            ->expects($this->any())
+            ->method('getRepository')
+            ->with(static::REFRESH_TOKEN_ENTITY_CLASS)
+            ->willReturn($this->repository);
+
+        $this->entityManager
+            ->expects($this->once())
+            ->method('getClassMetadata')
+            ->with(static::REFRESH_TOKEN_ENTITY_CLASS)
+            ->willReturn($classMetadataAlt);
+
+        $this->refreshTokenManagerAlt = new RefreshTokenManager(
+            $this->entityManager,
             static::REFRESH_TOKEN_ENTITY_CLASS,
             RefreshTokenManagerInterface::DEFAULT_BATCH_SIZE,
         );
@@ -132,26 +165,29 @@ class RefreshTokenManagerTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $query = $this->getMockBuilder(Query::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        
+        $query
+            ->method('execute')
+            ->willReturn(1);
+
         // Simula que el refreshToken tiene un id
         $refreshToken
             ->method('getId')
             ->willReturn(123);
 
-        $this->repository
-            ->method('findOneBy')
-            ->with(['id' => $refreshToken->getId()])
-            ->willReturn($refreshToken);
-
-        $this->objectManager
+        $this->entityManager
             ->expects($this->once())
-            ->method('remove')
-            ->with($refreshToken);
+            ->method('createQuery')
+            ->willReturn($query);
 
-        $this->objectManager
+        $this->entityManager
             ->expects($this->once())
             ->method('flush');
 
-        $result = $this->refreshTokenManager->delete($refreshToken, true);
+        $result = $this->refreshTokenManagerAlt->delete($refreshToken, true);
         $this->assertSame(1, $result);
     }
 


### PR DESCRIPTION
Use DQL to delete refresh-token, so that rows-affected can be returned.