### PR TITLE
Add support for Symfony 8

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.2', '8.3', '8.4']
-        symfony: ['6.4.*', '7.2.*', '7.3.*', "7.4.*", "8.0.*"]
+        symfony: ['6.4.*', '7.2.*', '7.3.*', '7.4.*', '8.0.*']
         composer-flags: ['--prefer-stable']
         can-fail: [false]
         extensions: ['curl, iconv, mbstring, mongodb, pdo, pdo_sqlite, sqlite, zip']

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.2', '8.3', '8.4']
-        symfony: ['6.4.*', '7.2.*', '7.3.*']
+        symfony: ['6.4.*', '7.2.*', '7.3.*', "7.4.*", "8.0.*"]
         composer-flags: ['--prefer-stable']
         can-fail: [false]
         extensions: ['curl, iconv, mbstring, mongodb, pdo, pdo_sqlite, sqlite, zip']

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The purpose of this bundle is manage refresh tokens with JWT (Json Web Tokens) i
 
 ## Prerequisites
 
-This bundle requires PHP 8.2 or later and Symfony 6.4, 7.2+, 8.0+.
+This bundle requires PHP 8.2 or later and Symfony 6.4, 7.2+ or 8.0+.
 
 For support with older Symfony versions, please use the 1.x release.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The purpose of this bundle is manage refresh tokens with JWT (Json Web Tokens) i
 
 ## Prerequisites
 
-This bundle requires PHP 8.2 or later and Symfony 6.4, or 7.2+.
+This bundle requires PHP 8.2 or later and Symfony 6.4, 7.2+, 8.0+.
 
 For support with older Symfony versions, please use the 1.x release.
 

--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,17 @@
     "php": ">=8.2",
     "doctrine/persistence": "^3.1 || ^4.0",
     "lexik/jwt-authentication-bundle": "^2.15 || ^3.0",
-    "symfony/config": "^6.4 || ^7.2",
-    "symfony/console": "^6.4 || ^7.2",
-    "symfony/dependency-injection": "^6.4 || ^7.2",
+    "symfony/config": "^6.4 || ^7.2 || ^8.0",
+    "symfony/console": "^6.4 || ^7.2 || ^8.0",
+    "symfony/dependency-injection": "^6.4 || ^7.2 || ^8.0",
     "symfony/deprecation-contracts": "^2.1 || ^3.0",
-    "symfony/event-dispatcher": "^6.4 || ^7.2",
-    "symfony/http-foundation": "^6.4 || ^7.2",
-    "symfony/http-kernel": "^6.4 || ^7.2",
-    "symfony/property-access": "^6.4 || ^7.2",
-    "symfony/security-bundle": "^6.4 || ^7.2",
-    "symfony/security-core": "^6.4 || ^7.2",
-    "symfony/security-http": "^6.4 || ^7.2"
+    "symfony/event-dispatcher": "^6.4 || ^7.2 || ^8.0",
+    "symfony/http-foundation": "^6.4 || ^7.2 || ^8.0",
+    "symfony/http-kernel": "^6.4 || ^7.2 || ^8.0",
+    "symfony/property-access": "^6.4 || ^7.2 || ^8.0",
+    "symfony/security-bundle": "^6.4 || ^7.2 || ^8.0",
+    "symfony/security-core": "^6.4 || ^7.2 || ^8.0",
+    "symfony/security-http": "^6.4 || ^7.2 || ^8.0"
   },
   "require-dev": {
     "doctrine/mongodb-odm": "^2.7",
@@ -39,7 +39,7 @@
     "phpunit/phpunit": "^10.5 || ^12.2",
     "rector/jack": "^0.2.5",
     "rector/rector": "^2.1",
-    "symfony/cache": "^6.4 || ^7.2"
+    "symfony/cache": "^6.4 || ^7.2 || ^8.0"
   },
   "conflict": {
     "doctrine/mongodb-odm": "<2.7",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "symfony/config": "^6.4 || ^7.2 || ^8.0",
     "symfony/console": "^6.4 || ^7.2 || ^8.0",
     "symfony/dependency-injection": "^6.4 || ^7.2 || ^8.0",
-    "symfony/deprecation-contracts": "^2.1 || ^3.0",
+    "symfony/deprecation-contracts": "^2.1 || ^3.0 || ^4.0",
     "symfony/event-dispatcher": "^6.4 || ^7.2 || ^8.0",
     "symfony/http-foundation": "^6.4 || ^7.2 || ^8.0",
     "symfony/http-kernel": "^6.4 || ^7.2 || ^8.0",


### PR DESCRIPTION
Added support for the newest version of Symfony. The upgraded packages have no significant changes and will continue to work as before.

The pipeline has been adjusted to accomidate for Symfony version 7.4 and 8.0.