### PR TITLE
Fix token revocation listing for tokens when using ODM

### DIFF
--- a/src/Command/ClearInvalidRefreshTokensCommand.php
+++ b/src/Command/ClearInvalidRefreshTokensCommand.php
@@ -66,7 +66,7 @@ final class ClearInvalidRefreshTokensCommand extends Command
             $io->text(sprintf('Revoked %d invalid token(s) in batches of %d', count($revokedTokens), $batchSize));
             $io->listing(array_map(
                 static fn (RefreshTokenInterface $revokedToken): string => $revokedToken->getRefreshToken(),
-                $revokedTokens,
+                iterator_to_array($revokedTokens),
             ));
         }
 


### PR DESCRIPTION
When using ODM, the result is not an array but
a CachingIterator. That needs to be converted
to an array for the array_map method, else it
crashes:

```
In ClearInvalidRefreshTokensCommand.php line 67:

  array_map(): Argument #2 ($array) must be of type array, Doctrine\ODM\MongoDB\Iterator\CachingIterator given

```

Also, if this could be patched as 1.5.x, that would be great as we are not in 2.x 🙏 