### PR TITLE
ci: fix security scan workflow

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -32,39 +32,21 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: ${{ matrix.php }}
           extensions: ${{ matrix.extensions }}
 
-      - name: Update Composer dependencies
-        run: composer update
-
-      - name: Install PHP MongoDB extension
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y php8.4-mongodb
-
-      - name: Install Composer dependencies
+      - name: Install Composer Dependencies
         run: composer install
 
-      - name: Mark /github/workspace as safe
-        run: git config --global --add safe.directory /github/workspace
-
       - name: Psalm Security Scan
-        uses: docker://ghcr.io/psalm/psalm-github-actions:6.13.0
-        with:
-          composer_require_dev: true
-          composer_ignore_platform_reqs: true
-          security_analysis: true
-          show_info: true
-          php_version: ${{ matrix.php }}
-          report_file: results.sarif
+        run: bin/psalm --force-jit --output-format=github --taint-analysis --report=results.sarif --show-info=true
 
       - name: Upload Security Analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
This PR fixes the psalm security workflow.

Not sure what is exactly broken with psalm/psalm-github-actions but it basically runs [this command](https://github.com/psalm/psalm-github-actions/blob/26f175f4d1d9006ea675bb78831ae94126017b07/entrypoint.sh#L89) against the code, so let's just do that directly.

This also uses the version of psalm from composer.json, so the results may be verified locally as well. Caching of composer dependencies could be added as well.